### PR TITLE
Add Auto Insurance sync line alongside ACA/Health

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,17 @@ CALLTOOLS_API_KEY=your_calltools_api_key_here
 
 # CallTools Base URL (optional, defaults to https://api.calltools.com/v1)
 CALLTOOLS_BASE_URL=https://api.calltools.com/v1
+
+# ---------------------------------------------------------------------------
+# Insurance line bucket IDs (CallTools)
+# Each insurance product routes cold leads and active clients to its own bucket.
+# ---------------------------------------------------------------------------
+
+# ACA / Health Insurance (defaults preserve the original hardcoded buckets)
+ACA_COLD_LEADS_BUCKET_ID=11237
+ACA_ACTIVE_CLIENTS_BUCKET_ID=11252
+
+# Auto Insurance - set these to the bucket IDs you created in CallTools.
+# Until set, Auto contacts are skipped with a clear "bucket not configured" error.
+AUTO_COLD_LEADS_BUCKET_ID=
+AUTO_ACTIVE_CLIENTS_BUCKET_ID=

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ CALLTOOLS_BASE_URL=https://api.calltools.com/v1
 ACA_COLD_LEADS_BUCKET_ID=11237
 ACA_ACTIVE_CLIENTS_BUCKET_ID=11252
 
-# Auto Insurance - set these to the bucket IDs you created in CallTools.
-# Until set, Auto contacts are skipped with a clear "bucket not configured" error.
-AUTO_COLD_LEADS_BUCKET_ID=
-AUTO_ACTIVE_CLIENTS_BUCKET_ID=
+# Auto Insurance bucket IDs (CallTools): cold -> hot -> active progression.
+AUTO_COLD_LEADS_BUCKET_ID=11880
+AUTO_HOT_LEADS_BUCKET_ID=11879
+AUTO_ACTIVE_CLIENTS_BUCKET_ID=11881

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ CALLTOOLS_BASE_URL=https://api.calltools.com/v1
 # ACA / Health Insurance (defaults preserve the original hardcoded buckets)
 ACA_COLD_LEADS_BUCKET_ID=11237
 ACA_ACTIVE_CLIENTS_BUCKET_ID=11252
+# Win-Back / Past Clients (ACA) - lapsed/cancelled clients to re-pursue
+ACA_WINBACK_BUCKET_ID=11238
 
 # Auto Insurance bucket IDs (CallTools): cold -> hot -> active progression.
 AUTO_COLD_LEADS_BUCKET_ID=11880

--- a/ACTIVE_CLIENTS_FEATURE.md
+++ b/ACTIVE_CLIENTS_FEATURE.md
@@ -259,6 +259,26 @@ The system attempts to remove contacts from Cold Leads bucket. If a contact rema
 2. Verify tag name is "ACA Active client" (exact)
 3. Check if tag already exists in CallTools
 
+## ACA Win-Back (lapsed / cancelled clients)
+
+When an ACA client lapses or cancels, tag them in GoHighLevel with
+`winback – aca` to re-pursue the sale. The integration then:
+
+- Adds the contact to the **Win-Back / Past Clients (ACA)** bucket (`11238`,
+  configurable via `ACA_WINBACK_BUCKET_ID`)
+- Applies the **`winback – aca`** CallTools tag (id `132076`)
+- Removes the contact from the **Cold Leads** (`11237`) and **ACA Active
+  clients** (`11252`) buckets and removes the `ACA Cold Lead` / `ACA Active
+  Client` tags
+- Resets the contact's customer flag so they are callable again (winback
+  overrides the "is customer / exclude from sync" guard)
+
+If the contact later re-buys (gets an `ACA Active` tag again), the active state
+takes priority and removes them from the Win-Back bucket/tag.
+
+> Tip: have your GoHighLevel winback workflow **remove the `ACA Active` tag** when
+> it adds `winback – aca`, so the active state doesn't out-prioritize winback.
+
 ## Related Documentation
 
 - [BUCKET_FEATURE.md](./BUCKET_FEATURE.md) - Cold Leads bucket details

--- a/AUTO_INSURANCE_FEATURE.md
+++ b/AUTO_INSURANCE_FEATURE.md
@@ -7,12 +7,18 @@ The GoHighLevel → CallTools integration now supports multiple **insurance line
 CallTools bucket and applies its own tags, so campaigns stay isolated.
 
 This mirrors the existing **ACA / Health Insurance** flow and adds a parallel
-**Auto Insurance** flow.
+**Auto Insurance** flow. Auto additionally has a **Hot Leads** tier (an engaged
+lead that isn't sold yet), so a contact progresses **cold → hot → active**.
 
-| Line | Cold lead bucket | Active client bucket | Cold lead tag | Active client tag |
-|------|------------------|----------------------|---------------|-------------------|
-| ACA / Health | `ACA_COLD_LEADS_BUCKET_ID` (default `11237`) | `ACA_ACTIVE_CLIENTS_BUCKET_ID` (default `11252`) | `ACA Cold lead` | `ACA Active client` |
-| Auto | `AUTO_COLD_LEADS_BUCKET_ID` | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `Auto Cold lead` | `Auto Active client` |
+### CallTools buckets
+
+| Line | Tier | Bucket | Default ID | CallTools tag |
+|------|------|--------|-----------|---------------|
+| ACA / Health | Cold | `ACA_COLD_LEADS_BUCKET_ID` | `11237` | `ACA Cold lead` |
+| ACA / Health | Active | `ACA_ACTIVE_CLIENTS_BUCKET_ID` | `11252` | `ACA Active client` |
+| Auto | Cold | `AUTO_COLD_LEADS_BUCKET_ID` | `11880` (Auto Insurance Cold Leads) | `Auto Cold lead` |
+| Auto | Hot | `AUTO_HOT_LEADS_BUCKET_ID` | `11879` (Auto Insurance Hot Leads) | `Auto Hot lead` |
+| Auto | Active | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `11881` (Auto Active Clients) | `Auto Active client` |
 
 ## How a contact is routed
 
@@ -20,12 +26,19 @@ When a contact is received (via webhook, workflow, or batch sync) its
 GoHighLevel tags are inspected by `matchInsuranceLine()`:
 
 1. **Active client check (highest priority).** If a tag exactly matches a
-   line's active-client tags, the contact is treated as an active client for
-   that line.
-2. **Generic customer exclusion.** Contacts tagged `customer` / `won` /
-   `purchased` (and not active for a line) are marked as customers and skipped.
-3. **Cold lead check.** If a tag contains one of a line's cold-lead fragments,
+   line's active-client tags, the contact is treated as an active client.
+2. **Hot lead check.** If a tag contains one of a line's hot-lead fragments
+   (only lines with a hot tier, i.e. Auto), the contact is promoted to the hot
+   bucket.
+3. **Generic customer exclusion.** Contacts tagged `customer` / `won` /
+   `purchased` (and not active/hot for a line) are marked as customers and skipped.
+4. **Cold lead check.** If a tag contains one of a line's cold-lead fragments,
    the contact is synced as a cold lead for that line.
+
+When a contact is promoted to a higher tier, it is added to that tier's bucket
+and tag and **removed from all lower-tier buckets/tags** (e.g. a hot lead is
+removed from the cold bucket; an active client is removed from both cold and hot
+buckets). Active clients are marked as customers; hot leads are not.
 
 Lines are evaluated **Auto before ACA** because Auto tags (e.g.
 `auto cold lead`) also contain the generic word `cold` that the ACA line
@@ -37,57 +50,59 @@ bucket.
 | Intent | Example GoHighLevel tags (case-insensitive) |
 |--------|---------------------------------------------|
 | Auto cold lead | `Auto Cold lead`, `Auto cold`, `Auto lead`, `Auto prospect`, `Auto new lead`, `Auto insurance` |
+| Auto hot lead | `Auto Hot lead`, `Auto hot`, `Auto warm` |
 | Auto active client | `Auto Active 2025`, `Auto Active 2026`, `Auto Active client` |
 
 ### What happens in CallTools
 
 **Auto cold lead:**
 - Creates/updates the contact in CallTools
-- Adds it to the **Auto cold leads** bucket
+- Adds it to the **Auto Insurance Cold Leads** bucket (`11880`)
 - Applies the **`Auto Cold lead`** tag
+
+**Auto hot lead:**
+- Creates/updates the contact in CallTools
+- Adds it to the **Auto Insurance Hot Leads** bucket (`11879`)
+- Removes it from the **Cold Leads** bucket (if present)
+- Applies the **`Auto Hot lead`** tag and removes **`Auto Cold lead`**
 
 **Auto active client:**
 - Creates/updates the contact in CallTools
-- Adds it to the **Auto active clients** bucket
-- Removes it from the **Auto cold leads** bucket (if present)
-- Applies the **`Auto Active client`** tag and removes **`Auto Cold lead`**
+- Adds it to the **Auto Active Clients** bucket (`11881`)
+- Removes it from the **Cold Leads** and **Hot Leads** buckets (if present)
+- Applies the **`Auto Active client`** tag and removes **`Auto Cold lead`** / **`Auto Hot lead`**
 - Marks the contact as a customer in the database
 
 ## Configuration
 
-Set the Auto bucket IDs so the line is active. Until both are set, Auto contacts
-are skipped with a clear `No ... bucket configured for line "Auto Insurance"`
-error (the ACA flow is unaffected).
+The Auto bucket IDs are configured out of the box with the real CallTools
+buckets (cold `11880`, hot `11879`, active `11881`). They can be overridden per
+deployment via env vars. If a required bucket is missing, that contact is
+skipped with a clear `No ... bucket configured for line "Auto Insurance"` error
+(the ACA flow is unaffected).
 
-### Local / `.env`
+### Cloudflare Worker (`wrangler.jsonc`)
 
-```bash
-AUTO_COLD_LEADS_BUCKET_ID=<your auto cold leads bucket id>
-AUTO_ACTIVE_CLIENTS_BUCKET_ID=<your auto active clients bucket id>
-```
-
-### Cloudflare Worker
-
-These are plain (non-secret) vars, set in `wrangler.jsonc`:
+These are plain (non-secret) vars:
 
 ```jsonc
 "vars": {
-  "AUTO_COLD_LEADS_BUCKET_ID": "12345",
-  "AUTO_ACTIVE_CLIENTS_BUCKET_ID": "12346"
+  "AUTO_COLD_LEADS_BUCKET_ID": "11880",
+  "AUTO_HOT_LEADS_BUCKET_ID": "11879",
+  "AUTO_ACTIVE_CLIENTS_BUCKET_ID": "11881"
 }
 ```
 
-Find the bucket IDs in CallTools (Lists / Buckets) or via the API
-`GET /api/lists/`. Create two new buckets first, e.g. "Auto Cold Leads" and
-"Auto Active Clients".
+Find bucket IDs in CallTools (Lists / Buckets) or via `GET /api/lists/`.
 
 ## GoHighLevel workflow setup
 
 Reuse the same webhook endpoint as ACA (`/webhook/ghl-workflow` or
 `/webhook/ghl`). Create workflows that fire when an Auto tag is added:
 
-1. **Trigger:** Contact Tag Added → tag is `Auto Cold lead` (cold campaign) or
-   `Auto Active 2025` / `Auto Active 2026` (active client).
+1. **Trigger:** Contact Tag Added → tag is `Auto Cold lead` (cold campaign),
+   `Auto Hot lead` (hot campaign), or `Auto Active 2025` / `Auto Active 2026`
+   (active client).
 2. **Action:** HTTP POST to your worker webhook URL with body:
 
 ```json

--- a/AUTO_INSURANCE_FEATURE.md
+++ b/AUTO_INSURANCE_FEATURE.md
@@ -23,8 +23,15 @@ Cold and Hot are mutually exclusive — a lead can move **cold ↔ hot** freely 
 a cold lead that shows renewed buying intent becomes hot and leaves the cold
 bucket), and going active leaves both.
 
-The matching tag also gets a CallTools tag applied (`Auto Hot lead`,
-`Auto Cold lead`, `Auto Active client`) and the removed-bucket tags are stripped.
+The matching tag also gets a CallTools tag applied and the removed-bucket tags
+are stripped. The CallTools tags (and their tag IDs) are:
+
+| State | CallTools tag | Tag ID |
+|-------|---------------|--------|
+| Hot | `Auto Insurance Hot Leads` | `142724` |
+| Cold | `Auto Insurance Cold Leads` | `142725` |
+| Active | `auto – active` | `142754` |
+
 Only `auto – active` marks the contact as a customer.
 
 ### CallTools buckets
@@ -33,9 +40,9 @@ Only `auto – active` marks the contact as a customer.
 |------|-------|--------|-----------|---------------|
 | ACA / Health | Cold | `ACA_COLD_LEADS_BUCKET_ID` | `11237` | `ACA Cold lead` |
 | ACA / Health | Active | `ACA_ACTIVE_CLIENTS_BUCKET_ID` | `11252` | `ACA Active client` |
-| Auto | Hot | `AUTO_HOT_LEADS_BUCKET_ID` | `11879` (Auto Insurance Hot Leads) | `Auto Hot lead` |
-| Auto | Cold | `AUTO_COLD_LEADS_BUCKET_ID` | `11880` (Auto Insurance Cold Leads) | `Auto Cold lead` |
-| Auto | Active | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `11881` (Auto Active Clients) | `Auto Active client` |
+| Auto | Hot | `AUTO_HOT_LEADS_BUCKET_ID` | `11879` (Auto Insurance Hot Leads) | `Auto Insurance Hot Leads` (142724) |
+| Auto | Cold | `AUTO_COLD_LEADS_BUCKET_ID` | `11880` (Auto Insurance Cold Leads) | `Auto Insurance Cold Leads` (142725) |
+| Auto | Active | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `11881` (Auto Active Clients) | `auto – active` (142754) |
 
 ## How a contact is routed
 
@@ -64,10 +71,10 @@ words like `cold` that the ACA line also matches.
 
 ### GoHighLevel tags that trigger the Auto line
 
-| State | GoHighLevel tags (case / dash / spacing insensitive) |
-|-------|------------------------------------------------------|
-| Auto hot lead | `auto – autoquote click` (also `autoquote click`, `autoquote`) |
-| Auto cold lead | `cold_lead_auto` |
+| State | GoHighLevel trigger tags (case / dash / spacing insensitive) |
+|-------|--------------------------------------------------------------|
+| Auto hot lead | `auto – autoquote click`, `Auto Insurance Hot Leads` (also `autoquote click`, `autoquote`) |
+| Auto cold lead | `cold_lead_auto`, `Auto Insurance Cold Leads` |
 | Auto active client | `auto – active` (also `auto active`, `auto active 2025/2026`, `auto active client`) |
 
 ### What happens in CallTools
@@ -75,20 +82,20 @@ words like `cold` that the ACA line also matches.
 **`auto – autoquote click` (hot lead):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Insurance Hot Leads** bucket (`11879`)
-- Removes it from the **Cold Leads** bucket (`11880`) and removes the `Auto Cold lead` tag
-- Applies the **`Auto Hot lead`** tag
+- Removes it from the **Cold Leads** bucket (`11880`) and removes the `Auto Insurance Cold Leads` tag
+- Applies the **`Auto Insurance Hot Leads`** tag (142724)
 
 **`cold_lead_auto` (cold lead):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Insurance Cold Leads** bucket (`11880`)
-- Removes it from the **Hot Leads** bucket (`11879`) and removes the `Auto Hot lead` tag
-- Applies the **`Auto Cold lead`** tag
+- Removes it from the **Hot Leads** bucket (`11879`) and removes the `Auto Insurance Hot Leads` tag
+- Applies the **`Auto Insurance Cold Leads`** tag (142725)
 
 **`auto – active` (active client):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Active Clients** bucket (`11881`)
 - Removes it from the **Cold Leads** (`11880`) and **Hot Leads** (`11879`) buckets and removes their tags
-- Applies the **`Auto Active client`** tag
+- Applies the **`auto – active`** tag (142754)
 - Marks the contact as a customer in the database
 
 ## Configuration

--- a/AUTO_INSURANCE_FEATURE.md
+++ b/AUTO_INSURANCE_FEATURE.md
@@ -15,9 +15,13 @@ These are the exact rules implemented for Auto:
 
 | GoHighLevel tag added | CallTools bucket added to | Removed from |
 |-----------------------|---------------------------|--------------|
-| `auto – autoquote click` | **Auto Insurance Hot Leads** (`11879`) | — |
+| `auto – autoquote click` | **Auto Insurance Hot Leads** (`11879`) | Cold Leads (`11880`) |
 | `cold_lead_auto` | **Auto Insurance Cold Leads** (`11880`) | Hot Leads (`11879`) |
 | `auto – active` | **Auto Active Clients** (`11881`) | Cold Leads (`11880`) + Hot Leads (`11879`) |
+
+Cold and Hot are mutually exclusive — a lead can move **cold ↔ hot** freely (e.g.
+a cold lead that shows renewed buying intent becomes hot and leaves the cold
+bucket), and going active leaves both.
 
 The matching tag also gets a CallTools tag applied (`Auto Hot lead`,
 `Auto Cold lead`, `Auto Active client`) and the removed-bucket tags are stripped.
@@ -41,12 +45,16 @@ collapsed) and inspected by `matchInsuranceLine()`. Each line declares states
 with the tags that trigger them and the buckets/tags to add and remove.
 
 If a contact has accumulated multiple matching tags, the **highest priority
-state wins**, in the order **active > cold > hot** (ties broken by line order,
-so Auto beats ACA). Practical effect:
+state wins**, in the order **active > hot > cold** (ties broken by line order,
+so Auto beats ACA). Hot beats cold so a lead showing renewed buying intent is
+not dragged back to the cold bucket by a stale cold tag. Practical effect:
 
-- `auto – autoquote click` only → **Hot**.
-- later tagged `cold_lead_auto` (now has both) → **Cold**, and removed from Hot.
-- later tagged `auto – active` (now has all three) → **Active**, removed from Cold + Hot.
+- `cold_lead_auto` only → **Cold**.
+- later tagged `auto – autoquote click` (renewed intent) → **Hot**, removed from Cold.
+- later tagged `auto – active` → **Active**, removed from Cold + Hot.
+
+To move a lead from hot back to cold, remove the `auto – autoquote click` tag in
+GoHighLevel (or have your workflow remove it) when adding `cold_lead_auto`.
 
 Contacts tagged with generic `customer` / `won` / `purchased` (and not matched
 as an active state) are marked as customers and skipped.
@@ -67,6 +75,7 @@ words like `cold` that the ACA line also matches.
 **`auto – autoquote click` (hot lead):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Insurance Hot Leads** bucket (`11879`)
+- Removes it from the **Cold Leads** bucket (`11880`) and removes the `Auto Cold lead` tag
 - Applies the **`Auto Hot lead`** tag
 
 **`cold_lead_auto` (cold lead):**

--- a/AUTO_INSURANCE_FEATURE.md
+++ b/AUTO_INSURANCE_FEATURE.md
@@ -1,0 +1,114 @@
+# Auto Insurance Line
+
+## Overview
+
+The GoHighLevel → CallTools integration now supports multiple **insurance lines
+(verticals)**. Each line routes its cold leads and active clients to its own
+CallTools bucket and applies its own tags, so campaigns stay isolated.
+
+This mirrors the existing **ACA / Health Insurance** flow and adds a parallel
+**Auto Insurance** flow.
+
+| Line | Cold lead bucket | Active client bucket | Cold lead tag | Active client tag |
+|------|------------------|----------------------|---------------|-------------------|
+| ACA / Health | `ACA_COLD_LEADS_BUCKET_ID` (default `11237`) | `ACA_ACTIVE_CLIENTS_BUCKET_ID` (default `11252`) | `ACA Cold lead` | `ACA Active client` |
+| Auto | `AUTO_COLD_LEADS_BUCKET_ID` | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `Auto Cold lead` | `Auto Active client` |
+
+## How a contact is routed
+
+When a contact is received (via webhook, workflow, or batch sync) its
+GoHighLevel tags are inspected by `matchInsuranceLine()`:
+
+1. **Active client check (highest priority).** If a tag exactly matches a
+   line's active-client tags, the contact is treated as an active client for
+   that line.
+2. **Generic customer exclusion.** Contacts tagged `customer` / `won` /
+   `purchased` (and not active for a line) are marked as customers and skipped.
+3. **Cold lead check.** If a tag contains one of a line's cold-lead fragments,
+   the contact is synced as a cold lead for that line.
+
+Lines are evaluated **Auto before ACA** because Auto tags (e.g.
+`auto cold lead`) also contain the generic word `cold` that the ACA line
+matches. Evaluating Auto first prevents Auto leads from being swept into the ACA
+bucket.
+
+### GoHighLevel tags that trigger the Auto line
+
+| Intent | Example GoHighLevel tags (case-insensitive) |
+|--------|---------------------------------------------|
+| Auto cold lead | `Auto Cold lead`, `Auto cold`, `Auto lead`, `Auto prospect`, `Auto new lead`, `Auto insurance` |
+| Auto active client | `Auto Active 2025`, `Auto Active 2026`, `Auto Active client` |
+
+### What happens in CallTools
+
+**Auto cold lead:**
+- Creates/updates the contact in CallTools
+- Adds it to the **Auto cold leads** bucket
+- Applies the **`Auto Cold lead`** tag
+
+**Auto active client:**
+- Creates/updates the contact in CallTools
+- Adds it to the **Auto active clients** bucket
+- Removes it from the **Auto cold leads** bucket (if present)
+- Applies the **`Auto Active client`** tag and removes **`Auto Cold lead`**
+- Marks the contact as a customer in the database
+
+## Configuration
+
+Set the Auto bucket IDs so the line is active. Until both are set, Auto contacts
+are skipped with a clear `No ... bucket configured for line "Auto Insurance"`
+error (the ACA flow is unaffected).
+
+### Local / `.env`
+
+```bash
+AUTO_COLD_LEADS_BUCKET_ID=<your auto cold leads bucket id>
+AUTO_ACTIVE_CLIENTS_BUCKET_ID=<your auto active clients bucket id>
+```
+
+### Cloudflare Worker
+
+These are plain (non-secret) vars, set in `wrangler.jsonc`:
+
+```jsonc
+"vars": {
+  "AUTO_COLD_LEADS_BUCKET_ID": "12345",
+  "AUTO_ACTIVE_CLIENTS_BUCKET_ID": "12346"
+}
+```
+
+Find the bucket IDs in CallTools (Lists / Buckets) or via the API
+`GET /api/lists/`. Create two new buckets first, e.g. "Auto Cold Leads" and
+"Auto Active Clients".
+
+## GoHighLevel workflow setup
+
+Reuse the same webhook endpoint as ACA (`/webhook/ghl-workflow` or
+`/webhook/ghl`). Create workflows that fire when an Auto tag is added:
+
+1. **Trigger:** Contact Tag Added → tag is `Auto Cold lead` (cold campaign) or
+   `Auto Active 2025` / `Auto Active 2026` (active client).
+2. **Action:** HTTP POST to your worker webhook URL with body:
+
+```json
+{
+  "contact_id": "{{contact.id}}"
+}
+```
+
+The integration reads the contact's tags and routes it to the correct Auto
+bucket automatically.
+
+## Adding more lines later
+
+The line definitions live in
+[`src/config/insuranceLines.ts`](./src/config/insuranceLines.ts). To add another
+vertical (e.g. Life, Medicare), add a new entry to `getInsuranceLines()` with
+its detection tags, bucket IDs, and CallTools tags. No changes to the sync
+service are required.
+
+## Related Documentation
+
+- [ACTIVE_CLIENTS_FEATURE.md](./ACTIVE_CLIENTS_FEATURE.md) - ACA active clients
+- [BUCKET_FEATURE.md](./BUCKET_FEATURE.md) - Cold Leads bucket details
+- [WEBHOOK_SETUP.md](./WEBHOOK_SETUP.md) - Webhook configuration

--- a/AUTO_INSURANCE_FEATURE.md
+++ b/AUTO_INSURANCE_FEATURE.md
@@ -7,70 +7,79 @@ The GoHighLevel → CallTools integration now supports multiple **insurance line
 CallTools bucket and applies its own tags, so campaigns stay isolated.
 
 This mirrors the existing **ACA / Health Insurance** flow and adds a parallel
-**Auto Insurance** flow. Auto additionally has a **Hot Leads** tier (an engaged
-lead that isn't sold yet), so a contact progresses **cold → hot → active**.
+**Auto Insurance** flow with three states: **hot**, **cold**, and **active**.
+
+### Auto Insurance: tag → bucket rules
+
+These are the exact rules implemented for Auto:
+
+| GoHighLevel tag added | CallTools bucket added to | Removed from |
+|-----------------------|---------------------------|--------------|
+| `auto – autoquote click` | **Auto Insurance Hot Leads** (`11879`) | — |
+| `cold_lead_auto` | **Auto Insurance Cold Leads** (`11880`) | Hot Leads (`11879`) |
+| `auto – active` | **Auto Active Clients** (`11881`) | Cold Leads (`11880`) + Hot Leads (`11879`) |
+
+The matching tag also gets a CallTools tag applied (`Auto Hot lead`,
+`Auto Cold lead`, `Auto Active client`) and the removed-bucket tags are stripped.
+Only `auto – active` marks the contact as a customer.
 
 ### CallTools buckets
 
-| Line | Tier | Bucket | Default ID | CallTools tag |
-|------|------|--------|-----------|---------------|
+| Line | State | Bucket | Default ID | CallTools tag |
+|------|-------|--------|-----------|---------------|
 | ACA / Health | Cold | `ACA_COLD_LEADS_BUCKET_ID` | `11237` | `ACA Cold lead` |
 | ACA / Health | Active | `ACA_ACTIVE_CLIENTS_BUCKET_ID` | `11252` | `ACA Active client` |
-| Auto | Cold | `AUTO_COLD_LEADS_BUCKET_ID` | `11880` (Auto Insurance Cold Leads) | `Auto Cold lead` |
 | Auto | Hot | `AUTO_HOT_LEADS_BUCKET_ID` | `11879` (Auto Insurance Hot Leads) | `Auto Hot lead` |
+| Auto | Cold | `AUTO_COLD_LEADS_BUCKET_ID` | `11880` (Auto Insurance Cold Leads) | `Auto Cold lead` |
 | Auto | Active | `AUTO_ACTIVE_CLIENTS_BUCKET_ID` | `11881` (Auto Active Clients) | `Auto Active client` |
 
 ## How a contact is routed
 
 When a contact is received (via webhook, workflow, or batch sync) its
-GoHighLevel tags are inspected by `matchInsuranceLine()`:
+GoHighLevel tags are normalized (lowercased, en/em dashes → hyphen, whitespace
+collapsed) and inspected by `matchInsuranceLine()`. Each line declares states
+with the tags that trigger them and the buckets/tags to add and remove.
 
-1. **Active client check (highest priority).** If a tag exactly matches a
-   line's active-client tags, the contact is treated as an active client.
-2. **Hot lead check.** If a tag contains one of a line's hot-lead fragments
-   (only lines with a hot tier, i.e. Auto), the contact is promoted to the hot
-   bucket.
-3. **Generic customer exclusion.** Contacts tagged `customer` / `won` /
-   `purchased` (and not active/hot for a line) are marked as customers and skipped.
-4. **Cold lead check.** If a tag contains one of a line's cold-lead fragments,
-   the contact is synced as a cold lead for that line.
+If a contact has accumulated multiple matching tags, the **highest priority
+state wins**, in the order **active > cold > hot** (ties broken by line order,
+so Auto beats ACA). Practical effect:
 
-When a contact is promoted to a higher tier, it is added to that tier's bucket
-and tag and **removed from all lower-tier buckets/tags** (e.g. a hot lead is
-removed from the cold bucket; an active client is removed from both cold and hot
-buckets). Active clients are marked as customers; hot leads are not.
+- `auto – autoquote click` only → **Hot**.
+- later tagged `cold_lead_auto` (now has both) → **Cold**, and removed from Hot.
+- later tagged `auto – active` (now has all three) → **Active**, removed from Cold + Hot.
 
-Lines are evaluated **Auto before ACA** because Auto tags (e.g.
-`auto cold lead`) also contain the generic word `cold` that the ACA line
-matches. Evaluating Auto first prevents Auto leads from being swept into the ACA
-bucket.
+Contacts tagged with generic `customer` / `won` / `purchased` (and not matched
+as an active state) are marked as customers and skipped.
+
+Lines are evaluated **Auto before ACA** because Auto tags can contain generic
+words like `cold` that the ACA line also matches.
 
 ### GoHighLevel tags that trigger the Auto line
 
-| Intent | Example GoHighLevel tags (case-insensitive) |
-|--------|---------------------------------------------|
-| Auto cold lead | `Auto Cold lead`, `Auto cold`, `Auto lead`, `Auto prospect`, `Auto new lead`, `Auto insurance` |
-| Auto hot lead | `Auto Hot lead`, `Auto hot`, `Auto warm` |
-| Auto active client | `Auto Active 2025`, `Auto Active 2026`, `Auto Active client` |
+| State | GoHighLevel tags (case / dash / spacing insensitive) |
+|-------|------------------------------------------------------|
+| Auto hot lead | `auto – autoquote click` (also `autoquote click`, `autoquote`) |
+| Auto cold lead | `cold_lead_auto` |
+| Auto active client | `auto – active` (also `auto active`, `auto active 2025/2026`, `auto active client`) |
 
 ### What happens in CallTools
 
-**Auto cold lead:**
-- Creates/updates the contact in CallTools
-- Adds it to the **Auto Insurance Cold Leads** bucket (`11880`)
-- Applies the **`Auto Cold lead`** tag
-
-**Auto hot lead:**
+**`auto – autoquote click` (hot lead):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Insurance Hot Leads** bucket (`11879`)
-- Removes it from the **Cold Leads** bucket (if present)
-- Applies the **`Auto Hot lead`** tag and removes **`Auto Cold lead`**
+- Applies the **`Auto Hot lead`** tag
 
-**Auto active client:**
+**`cold_lead_auto` (cold lead):**
+- Creates/updates the contact in CallTools
+- Adds it to the **Auto Insurance Cold Leads** bucket (`11880`)
+- Removes it from the **Hot Leads** bucket (`11879`) and removes the `Auto Hot lead` tag
+- Applies the **`Auto Cold lead`** tag
+
+**`auto – active` (active client):**
 - Creates/updates the contact in CallTools
 - Adds it to the **Auto Active Clients** bucket (`11881`)
-- Removes it from the **Cold Leads** and **Hot Leads** buckets (if present)
-- Applies the **`Auto Active client`** tag and removes **`Auto Cold lead`** / **`Auto Hot lead`**
+- Removes it from the **Cold Leads** (`11880`) and **Hot Leads** (`11879`) buckets and removes their tags
+- Applies the **`Auto Active client`** tag
 - Marks the contact as a customer in the database
 
 ## Configuration
@@ -100,9 +109,9 @@ Find bucket IDs in CallTools (Lists / Buckets) or via `GET /api/lists/`.
 Reuse the same webhook endpoint as ACA (`/webhook/ghl-workflow` or
 `/webhook/ghl`). Create workflows that fire when an Auto tag is added:
 
-1. **Trigger:** Contact Tag Added → tag is `Auto Cold lead` (cold campaign),
-   `Auto Hot lead` (hot campaign), or `Auto Active 2025` / `Auto Active 2026`
-   (active client).
+1. **Trigger:** Contact Tag Added → tag is `auto – autoquote click` (hot
+   campaign), `cold_lead_auto` (cold campaign), or `auto – active` (active
+   client).
 2. **Action:** HTTP POST to your worker webhook URL with body:
 
 ```json
@@ -119,8 +128,8 @@ bucket automatically.
 The line definitions live in
 [`src/config/insuranceLines.ts`](./src/config/insuranceLines.ts). To add another
 vertical (e.g. Life, Medicare), add a new entry to `getInsuranceLines()` with
-its detection tags, bucket IDs, and CallTools tags. No changes to the sync
-service are required.
+its `states` (each state's trigger tags, target bucket/tag, and which
+buckets/tags to remove). No changes to the sync service are required.
 
 ## Related Documentation
 

--- a/CALLTOOLS_LIVE_FILTERS.md
+++ b/CALLTOOLS_LIVE_FILTERS.md
@@ -1,0 +1,119 @@
+# CallTools API ↔ Live Filters: Integration Audit
+
+This documents what our GoHighLevel → CallTools integration can and cannot do
+with respect to CallTools **Live Filters**, based on the CallTools developer
+docs and our current client (`src/clients/calltools.ts`).
+
+## TL;DR
+
+- **Live Filters are configured in the CallTools UI**, not through the API.
+  (Contact Center → Campaigns → Live Filters.) They are IF/THEN rule sets that
+  dynamically decide which contacts are dialable, refreshing ~every 15 minutes,
+  up to 20 active filters.
+- **The API cannot create or manage Live Filters.** Per CallTools API
+  conventions: *"you cannot manage Live Filters directly via the API, but you
+  can filter API data results using the same fields available in the platform."*
+- **Our leverage is the data we push in.** Live Filters segment on bucket/list
+  membership, tags, contact status, dispositions, and custom field values — all
+  of which we (the integration) populate. So the way to "do more with Live
+  Filters" is to feed CallTools richer, well-structured data, then build the
+  matching Live Filters once in the UI.
+
+## What Live Filters can segment on
+
+Live Filters build dialer queues using IF/THEN rules over:
+
+- **Lists/Buckets** (include/exclude) — e.g. our `Auto Insurance Hot Leads`,
+  `Auto Insurance Cold Leads`, `Auto Active Clients` buckets.
+- **Tags** — e.g. `Auto Hot lead`, `Auto Cold lead`, `Auto Active client`.
+- **Contact status / disposition** — call outcomes set by agents/dialer.
+- **Custom field values** — any custom contact fields defined in the account.
+- **Compliance** — DNC (FDNC) suppression, State calling hours, Holidays,
+  Time-Zone protection, and callback (True/False) logic.
+
+## What our integration already feeds (usable by Live Filters today)
+
+From `src/clients/calltools.ts` + `src/services/contactSyncService.ts`:
+
+- **Bucket membership** — contacts are added to the correct line/state bucket
+  and removed from the others (cold ↔ hot ↔ active). ✔
+- **Tags** — line/state tags are added and the opposing tags removed. ✔
+- **Core fields** — `first_name`, `last_name`, `mobile_phone_number`,
+  `personal_email_address`. ✔
+
+This is already enough to build solid Live Filters (see below).
+
+## Recommended Live Filters to configure in CallTools (UI)
+
+Create these once in the UI; our integration keeps the bucket/tag membership
+accurate so the queues stay correct automatically.
+
+| Live Filter | Include | Exclude | Compliance |
+|-------------|---------|---------|------------|
+| **Auto – Hot Queue** | bucket `Auto Insurance Hot Leads` (11879) | `Auto Active Clients` (11881) | FDNC + State hours + Time-zone |
+| **Auto – Cold Queue** | bucket `Auto Insurance Cold Leads` (11880) | Hot (11879), Active (11881) | FDNC + State hours + Time-zone |
+| **Auto – Active (service)** | bucket `Auto Active Clients` (11881) | — | Time-zone |
+| **ACA – Cold Queue** | bucket `Cold Leads` (11237) | `ACA Active clients` (11252) | FDNC + State hours + Time-zone |
+| **ACA – Active** | bucket `ACA Active clients` (11252) | — | Time-zone |
+
+Because hot/cold/active membership is mutually exclusive in our sync, the
+"Exclude" rules are mostly belt-and-suspenders, but they protect against any
+contact that briefly carries two tags between webhook events.
+
+## Optional enhancement: push custom fields for richer filtering
+
+Today we only send name/phone/email. If you want Live Filters (and reporting)
+to segment on more than bucket/tag, we can also write **custom contact fields**.
+Useful candidates:
+
+| Field (suggested slug) | Example value | Enables Live Filter like… |
+|------------------------|---------------|---------------------------|
+| `insurance_line` | `auto` / `aca` | "only Auto leads" |
+| `lead_state` | `hot` / `cold` / `active` | "hot leads updated today" |
+| `lead_source` | `ghl` / campaign name | source-based queues |
+| `ghl_contact_id` | GHL id | dedupe / write-back to GHL |
+| `state_changed_at` | `YYYY-MM-DD HH:MM:SS` (UTC) | "went hot in last 24h" |
+
+Requirements / caveats before implementing:
+- **Custom fields must first be created in the CallTools account** (by
+  name/slug). The API writes to existing fields; unknown fields are ignored.
+- Date/datetime custom fields must use `YYYY-MM-DD` / `YYYY-MM-DD HH:MM:SS`.
+  User-entered date fields are treated as naive/local (not UTC).
+- Our `CallToolsContact` type already has a `custom_fields` slot, so wiring this
+  is small once the field slugs are known.
+
+If you create those fields in CallTools and share the exact slugs, the
+integration can start populating them on every sync.
+
+## API conventions — our client is compliant
+
+Verified against https://calltools.com/developers/api-conventions/:
+
+- **Auth**: `Authorization: Token {key}` ✔ (we use this)
+- **Trailing slash** on endpoints (`/api/contacts/`, `/api/buckets/{id}/`,
+  `/api/alltags/`) ✔
+- **Silo subdomain**: we use `https://east-1.calltools.io` ✔ (CallTools is
+  sharded into per-client `*.calltools.io` silos; ours is `east-1`)
+- **JSON** request bodies ✔
+- **Filtering** via query params (we use `?phone_number=` and `?name=`) ✔
+
+### Things to watch
+
+- **Rate limit: 1000 requests/hour per API key.** A single active-client sync
+  makes several calls (search + update + add bucket + add tag + N× remove
+  bucket/tag, and each tag op is a GET + PATCH). High webhook volume could
+  approach the limit; consider batching or backoff if you scale up.
+- **Paging defaults to 25, max 250** (`?page_size=max`). Not an issue for our
+  current phone-number lookups, but relevant if we ever list all
+  buckets/contacts.
+- **Bulk delete** is available on `/api/contacts/` with query-param filters —
+  powerful but dangerous (no filter = deletes everything). We don't use it.
+
+## Bottom line
+
+We don't (and can't) build Live Filters from code. The integration's job is to
+keep CallTools' **buckets, tags, and (optionally) custom fields** accurate and
+well-structured; the Live Filters are then configured once in the CallTools UI
+to turn that structure into compliant, dynamic dialer queues. Our current
+bucket + tag sync is already a solid foundation; adding custom fields is the
+main lever for finer-grained Live Filters.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Cloudflare Worker that automatically syncs cold contacts from GoHighLevel to C
 ## 🚀 Features
 
 - ⚡ **Real-Time Webhook Sync** - Contacts sync instantly when tagged "cold lead" or "ACA Active"
+- 🚗 **Multi-Line Support** - Separate routing/buckets/tags per insurance line (ACA/Health + Auto). See [AUTO_INSURANCE_FEATURE.md](./AUTO_INSURANCE_FEATURE.md)
 - 📦 **Automatic Bucket Management** - Organizes contacts in "Cold Leads" and "ACA Active clients" buckets
 - 🎯 **Active Client Management** - Automatically moves sold contacts to active clients bucket with proper tags
 - 🏷️ **Smart Tag Management** - Adds/removes tags based on contact status (cold lead ↔ active client)

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":226,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":20,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":64,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":203,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":15,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":67,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":267,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":21,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":61,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":226,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":20,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":64,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":197,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":19,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":51,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":267,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":21,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":61,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":665,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":59,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":198,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":23,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":198,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":23,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":197,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":18,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":203,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":15,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":67,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":256,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":17,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":79,"failed":false}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,1 @@
-{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":197,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":18,"failed":false}]]}
+{"version":"3.2.4","results":[[":tests/integration/tasks.test.ts",{"duration":197,"failed":false}],[":tests/integration/dummyEndpoint.test.ts",{"duration":19,"failed":false}],[":tests/integration/insuranceLines.test.ts",{"duration":51,"failed":false}]]}

--- a/src/clients/gohighlevel.ts
+++ b/src/clients/gohighlevel.ts
@@ -80,29 +80,36 @@ export class GoHighLevelClient {
   }
 
   /**
-   * Get cold contacts (contacts with "cold lead" tag)
-   * Excluding customers (contacts with "customer" tag or in customer pipeline stage)
+   * Fetch every contact in the account (paginated).
+   * Used by the batch sync to route contacts across all insurance lines.
    */
-  async getColdContactsExcludingCustomers(): Promise<GHLContact[]> {
+  async getAllContacts(): Promise<GHLContact[]> {
     const allContacts: GHLContact[] = [];
     let skip = 0;
     const limit = 100;
     let hasMore = true;
 
-    // Fetch all contacts in batches
     while (hasMore) {
       const response = await this.getContacts({ limit, skip });
-      
+
       if (response.contacts && response.contacts.length > 0) {
         allContacts.push(...response.contacts);
         skip += limit;
-        
-        // Check if there are more pages
         hasMore = response.contacts.length === limit;
       } else {
         hasMore = false;
       }
     }
+
+    return allContacts;
+  }
+
+  /**
+   * Get cold contacts (contacts with "cold lead" tag)
+   * Excluding customers (contacts with "customer" tag or in customer pipeline stage)
+   */
+  async getColdContactsExcludingCustomers(): Promise<GHLContact[]> {
+    const allContacts = await this.getAllContacts();
 
     // Filter for cold contacts, excluding customers
     const coldContacts = allContacts.filter(contact => {

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -23,13 +23,16 @@ export type StateName = 'cold' | 'hot' | 'active';
 /**
  * Detection/priority ordering when a contact matches more than one state.
  * Lower number = higher priority. A contact that has accumulated several tags
- * (e.g. an old "hot" tag plus a new "cold" tag) resolves to the highest
- * priority state, so: active > cold > hot.
+ * resolves to the highest priority state, so: active > hot > cold.
+ *
+ * Hot beats cold so that a lead showing renewed buying intent (hot) is not
+ * pulled back into the cold bucket just because an old cold tag is still
+ * present. To move a lead back to cold, remove the hot tag in GoHighLevel.
  */
 export const STATE_PRIORITY: Record<StateName, number> = {
   active: 0,
-  cold: 1,
-  hot: 2,
+  hot: 1,
+  cold: 2,
 };
 
 export interface LineState {
@@ -117,8 +120,9 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
           matchers: ['auto - autoquote click', 'autoquote click', 'autoquote'],
           bucketId: autoHot,
           tag: 'Auto Hot lead',
-          removeBucketIds: [],
-          removeTags: [],
+          // Leads can move cold <-> hot, so going hot removes the cold bucket/tag.
+          removeBucketIds: [autoCold],
+          removeTags: ['Auto Cold lead'],
           isCustomer: false,
         },
         {
@@ -181,7 +185,7 @@ export interface LineMatch {
  * Determine which insurance line + state a set of GoHighLevel tags maps to.
  *
  * If multiple states match (e.g. accumulated tags), the highest priority state
- * wins (active > cold > hot). Ties are broken by line order, so Auto beats ACA.
+ * wins (active > hot > cold). Ties are broken by line order, so Auto beats ACA.
  */
 export function matchInsuranceLine(
   tags: string[],

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -5,54 +5,60 @@
  * insurance products ("lines of business") are routed to different CallTools
  * buckets and tagged differently so each campaign stays isolated.
  *
- * Each line can have up to three tiers a contact progresses through:
- *   cold  -> hot (optional) -> active (sold)
+ * Each line declares a set of "states" (cold lead, hot lead, active client).
+ * A state is triggered by GoHighLevel tags and, when matched, the contact is:
+ *   - added to that state's CallTools bucket + tag
+ *   - removed from the buckets/tags listed in `removeBucketIds` / `removeTags`
  *
- * Each tier maps to its own CallTools bucket and tag. When a contact moves up a
- * tier it is added to the higher bucket/tag and removed from the lower ones.
+ * This explicit add/remove model lets each tag do exactly what the business
+ * wants (e.g. "cold removes from hot"), without assuming a fixed tier ordering.
  *
- * Lines are evaluated in array order, so more specific lines (e.g. Auto, whose
- * tags also contain generic words like "cold") MUST come before more generic
- * lines (ACA) to avoid mis-routing.
+ * Lines are evaluated so that more specific lines (Auto, whose tags contain
+ * generic words like "cold") win over generic lines (ACA) at the same state
+ * priority.
  */
+
+export type StateName = 'cold' | 'hot' | 'active';
+
+/**
+ * Detection/priority ordering when a contact matches more than one state.
+ * Lower number = higher priority. A contact that has accumulated several tags
+ * (e.g. an old "hot" tag plus a new "cold" tag) resolves to the highest
+ * priority state, so: active > cold > hot.
+ */
+export const STATE_PRIORITY: Record<StateName, number> = {
+  active: 0,
+  cold: 1,
+  hot: 2,
+};
+
+export interface LineState {
+  /** Which tier this state represents. */
+  name: StateName;
+  /**
+   * GoHighLevel tag fragments (will be normalized) that trigger this state.
+   * Matched as a normalized substring (case/dash/space insensitive).
+   */
+  matchers: string[];
+  /** CallTools bucket/list ID the contact is added to. */
+  bucketId: string;
+  /** CallTools tag applied to the contact. */
+  tag: string;
+  /** CallTools bucket/list IDs the contact is removed from. */
+  removeBucketIds: string[];
+  /** CallTools tags removed from the contact. */
+  removeTags: string[];
+  /** Whether reaching this state marks the contact as a customer (excluded from cold syncs). */
+  isCustomer: boolean;
+}
 
 export interface InsuranceLineConfig {
   /** Stable identifier for the line, e.g. "aca" or "auto". */
   key: string;
   /** Human friendly label used in logs / responses. */
   label: string;
-
-  // ---- GoHighLevel tag detection ----
-  /**
-   * Tags (lowercase) that mark a contact as an active/sold client for this
-   * line. Matched exactly (case-insensitive).
-   */
-  activeClientTags: string[];
-  /**
-   * Tag fragments (lowercase) that mark a contact as a hot lead for this line.
-   * Matched as a substring (case-insensitive). Optional - omit for lines
-   * without a hot-lead tier.
-   */
-  hotLeadMatchers?: string[];
-  /**
-   * Tag fragments (lowercase) that mark a contact as a cold lead for this line.
-   * Matched as a substring (case-insensitive).
-   */
-  coldLeadMatchers: string[];
-
-  // ---- CallTools targets ----
-  /** CallTools bucket/list ID that cold leads are added to. */
-  coldLeadsBucketId: string;
-  /** CallTools bucket/list ID that hot leads are moved to (optional). */
-  hotLeadsBucketId?: string;
-  /** CallTools bucket/list ID that active clients are moved to. */
-  activeClientsBucketId: string;
-  /** CallTools tag applied to cold leads for this line. */
-  coldLeadTag: string;
-  /** CallTools tag applied to hot leads for this line (optional). */
-  hotLeadTag?: string;
-  /** CallTools tag applied to active clients for this line. */
-  activeClientTag: string;
+  /** The states (tiers) this line supports. */
+  states: LineState[];
 }
 
 /**
@@ -74,100 +80,134 @@ function pick(value: string | undefined, fallback: string): string {
 }
 
 /**
+ * Normalize a tag (or matcher) for comparison: lowercase, convert en/em dashes
+ * to a plain hyphen, and collapse runs of whitespace. Underscores are kept so
+ * tags like `cold_lead_auto` match exactly.
+ */
+export function normalizeTag(tag: string): string {
+  return String(tag)
+    .toLowerCase()
+    .replace(/[\u2012\u2013\u2014\u2015]/g, '-') // figure/en/em/horizontal dashes -> hyphen
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
  * Build the list of insurance lines for the current environment.
  *
- * NOTE: order matters. Auto is listed first because its cold-lead tags (e.g.
- * "auto cold lead") also contain generic words like "cold" that the ACA line
- * matches. Evaluating Auto first guarantees Auto contacts are not swept into
- * the ACA bucket.
+ * NOTE: Auto is listed before ACA so that Auto tags (which contain generic
+ * words like "cold") are routed to Auto buckets rather than ACA.
  */
 export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] {
+  const autoCold = pick(env.AUTO_COLD_LEADS_BUCKET_ID, '11880');
+  const autoHot = pick(env.AUTO_HOT_LEADS_BUCKET_ID, '11879');
+  const autoActive = pick(env.AUTO_ACTIVE_CLIENTS_BUCKET_ID, '11881');
+
+  const acaCold = pick(env.ACA_COLD_LEADS_BUCKET_ID, '11237');
+  const acaActive = pick(env.ACA_ACTIVE_CLIENTS_BUCKET_ID, '11252');
+
   return [
     {
       key: 'auto',
       label: 'Auto Insurance',
-      activeClientTags: ['auto active 2025', 'auto active 2026', 'auto active client'],
-      hotLeadMatchers: ['auto hot lead', 'auto hot', 'auto warm'],
-      coldLeadMatchers: [
-        'auto cold lead',
-        'auto cold',
-        'auto lead',
-        'auto prospect',
-        'auto insurance',
-        'auto new lead',
+      states: [
+        {
+          name: 'hot',
+          // GHL tag: "auto – autoquote click"
+          matchers: ['auto - autoquote click', 'autoquote click', 'autoquote'],
+          bucketId: autoHot,
+          tag: 'Auto Hot lead',
+          removeBucketIds: [],
+          removeTags: [],
+          isCustomer: false,
+        },
+        {
+          name: 'cold',
+          // GHL tag: "cold_lead_auto"
+          matchers: ['cold_lead_auto', 'cold lead auto'],
+          bucketId: autoCold,
+          tag: 'Auto Cold lead',
+          // Adding to cold removes the contact from the hot bucket/tag.
+          removeBucketIds: [autoHot],
+          removeTags: ['Auto Hot lead'],
+          isCustomer: false,
+        },
+        {
+          name: 'active',
+          // GHL tag: "auto – active"
+          matchers: ['auto - active', 'auto active', 'auto active client', 'auto active 2025', 'auto active 2026'],
+          bucketId: autoActive,
+          tag: 'Auto Active client',
+          // Active removes the contact from both cold and hot.
+          removeBucketIds: [autoCold, autoHot],
+          removeTags: ['Auto Cold lead', 'Auto Hot lead'],
+          isCustomer: true,
+        },
       ],
-      // CallTools bucket IDs (override per deployment via env vars).
-      coldLeadsBucketId: pick(env.AUTO_COLD_LEADS_BUCKET_ID, '11880'),
-      hotLeadsBucketId: pick(env.AUTO_HOT_LEADS_BUCKET_ID, '11879'),
-      activeClientsBucketId: pick(env.AUTO_ACTIVE_CLIENTS_BUCKET_ID, '11881'),
-      coldLeadTag: 'Auto Cold lead',
-      hotLeadTag: 'Auto Hot lead',
-      activeClientTag: 'Auto Active client',
     },
     {
       key: 'aca',
       label: 'ACA / Health Insurance',
-      activeClientTags: ['aca active 2025', 'aca active 2026', 'aca active client'],
-      coldLeadMatchers: ['cold lead', 'cold', 'new lead', 'prospect'],
-      // Preserve the historical hardcoded ACA bucket IDs as defaults.
-      coldLeadsBucketId: pick(env.ACA_COLD_LEADS_BUCKET_ID, '11237'),
-      activeClientsBucketId: pick(env.ACA_ACTIVE_CLIENTS_BUCKET_ID, '11252'),
-      coldLeadTag: 'ACA Cold lead',
-      activeClientTag: 'ACA Active client',
+      states: [
+        {
+          name: 'cold',
+          matchers: ['cold lead', 'cold', 'new lead', 'prospect'],
+          bucketId: acaCold,
+          tag: 'ACA Cold lead',
+          removeBucketIds: [],
+          removeTags: [],
+          isCustomer: false,
+        },
+        {
+          name: 'active',
+          matchers: ['aca active 2025', 'aca active 2026', 'aca active client'],
+          bucketId: acaActive,
+          tag: 'ACA Active client',
+          removeBucketIds: [acaCold],
+          removeTags: ['ACA Cold lead'],
+          isCustomer: true,
+        },
+      ],
     },
   ];
 }
 
-export type MatchType = 'active' | 'hot' | 'cold';
-
 export interface LineMatch {
   line: InsuranceLineConfig;
-  type: MatchType;
+  state: LineState;
 }
 
 /**
- * Determine which insurance line (and which tier) a set of GoHighLevel tags
- * belongs to.
+ * Determine which insurance line + state a set of GoHighLevel tags maps to.
  *
- * Priority is active > hot > cold, evaluated across all lines in the order
- * returned by {@link getInsuranceLines}.
+ * If multiple states match (e.g. accumulated tags), the highest priority state
+ * wins (active > cold > hot). Ties are broken by line order, so Auto beats ACA.
  */
 export function matchInsuranceLine(
   tags: string[],
   lines: InsuranceLineConfig[]
 ): LineMatch | null {
-  const lowerTags = tags.map((t) => t.toLowerCase().trim());
+  const normalizedTags = tags.map(normalizeTag).filter((t) => t.length > 0);
 
-  // 1. Active clients (exact tag match) across all lines.
-  for (const line of lines) {
-    const isActive = lowerTags.some((tag) => line.activeClientTags.includes(tag));
-    if (isActive) {
-      return { line, type: 'active' };
-    }
-  }
+  let best: LineMatch | null = null;
+  let bestRank = Number.POSITIVE_INFINITY;
 
-  // 2. Hot leads (substring match) for lines that define a hot tier.
-  for (const line of lines) {
-    if (!line.hotLeadMatchers || !line.hotLeadsBucketId) {
-      continue;
+  lines.forEach((line, lineIndex) => {
+    for (const state of line.states) {
+      const matched = normalizedTags.some((tag) =>
+        state.matchers.some((matcher) => tag.includes(normalizeTag(matcher)))
+      );
+      if (!matched) {
+        continue;
+      }
+      // Composite rank: state priority dominates, line order is the tie-breaker.
+      const rank = STATE_PRIORITY[state.name] * 100 + lineIndex;
+      if (rank < bestRank) {
+        bestRank = rank;
+        best = { line, state };
+      }
     }
-    const isHot = lowerTags.some((tag) =>
-      line.hotLeadMatchers!.some((matcher) => tag.includes(matcher))
-    );
-    if (isHot) {
-      return { line, type: 'hot' };
-    }
-  }
+  });
 
-  // 3. Cold leads (substring match) in line priority order.
-  for (const line of lines) {
-    const isCold = lowerTags.some((tag) =>
-      line.coldLeadMatchers.some((matcher) => tag.includes(matcher))
-    );
-    if (isCold) {
-      return { line, type: 'cold' };
-    }
-  }
-
-  return null;
+  return best;
 }

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -5,10 +5,11 @@
  * insurance products ("lines of business") are routed to different CallTools
  * buckets and tagged differently so each campaign stays isolated.
  *
- * Each line defines:
- *  - how to detect cold leads / active clients from GoHighLevel tags
- *  - which CallTools bucket cold leads and active clients land in
- *  - which CallTools tags are applied for cold leads and active clients
+ * Each line can have up to three tiers a contact progresses through:
+ *   cold  -> hot (optional) -> active (sold)
+ *
+ * Each tier maps to its own CallTools bucket and tag. When a contact moves up a
+ * tier it is added to the higher bucket/tag and removed from the lower ones.
  *
  * Lines are evaluated in array order, so more specific lines (e.g. Auto, whose
  * tags also contain generic words like "cold") MUST come before more generic
@@ -20,22 +21,36 @@ export interface InsuranceLineConfig {
   key: string;
   /** Human friendly label used in logs / responses. */
   label: string;
+
+  // ---- GoHighLevel tag detection ----
   /**
-   * GoHighLevel tags (lowercase) that mark a contact as an active/sold client
-   * for this line. Matched exactly (case-insensitive).
+   * Tags (lowercase) that mark a contact as an active/sold client for this
+   * line. Matched exactly (case-insensitive).
    */
   activeClientTags: string[];
   /**
-   * GoHighLevel tag fragments (lowercase) that mark a contact as a cold lead
-   * for this line. Matched as a substring (case-insensitive).
+   * Tag fragments (lowercase) that mark a contact as a hot lead for this line.
+   * Matched as a substring (case-insensitive). Optional - omit for lines
+   * without a hot-lead tier.
+   */
+  hotLeadMatchers?: string[];
+  /**
+   * Tag fragments (lowercase) that mark a contact as a cold lead for this line.
+   * Matched as a substring (case-insensitive).
    */
   coldLeadMatchers: string[];
+
+  // ---- CallTools targets ----
   /** CallTools bucket/list ID that cold leads are added to. */
   coldLeadsBucketId: string;
+  /** CallTools bucket/list ID that hot leads are moved to (optional). */
+  hotLeadsBucketId?: string;
   /** CallTools bucket/list ID that active clients are moved to. */
   activeClientsBucketId: string;
   /** CallTools tag applied to cold leads for this line. */
   coldLeadTag: string;
+  /** CallTools tag applied to hot leads for this line (optional). */
+  hotLeadTag?: string;
   /** CallTools tag applied to active clients for this line. */
   activeClientTag: string;
 }
@@ -49,6 +64,7 @@ export interface InsuranceLineEnv {
   ACA_COLD_LEADS_BUCKET_ID?: string;
   ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
   AUTO_COLD_LEADS_BUCKET_ID?: string;
+  AUTO_HOT_LEADS_BUCKET_ID?: string;
   AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;
 }
 
@@ -71,6 +87,7 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
       key: 'auto',
       label: 'Auto Insurance',
       activeClientTags: ['auto active 2025', 'auto active 2026', 'auto active client'],
+      hotLeadMatchers: ['auto hot lead', 'auto hot', 'auto warm'],
       coldLeadMatchers: [
         'auto cold lead',
         'auto cold',
@@ -79,10 +96,12 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
         'auto insurance',
         'auto new lead',
       ],
-      // Configure these via env vars; no safe default exists for Auto buckets.
-      coldLeadsBucketId: pick(env.AUTO_COLD_LEADS_BUCKET_ID, ''),
-      activeClientsBucketId: pick(env.AUTO_ACTIVE_CLIENTS_BUCKET_ID, ''),
+      // CallTools bucket IDs (override per deployment via env vars).
+      coldLeadsBucketId: pick(env.AUTO_COLD_LEADS_BUCKET_ID, '11880'),
+      hotLeadsBucketId: pick(env.AUTO_HOT_LEADS_BUCKET_ID, '11879'),
+      activeClientsBucketId: pick(env.AUTO_ACTIVE_CLIENTS_BUCKET_ID, '11881'),
       coldLeadTag: 'Auto Cold lead',
+      hotLeadTag: 'Auto Hot lead',
       activeClientTag: 'Auto Active client',
     },
     {
@@ -99,7 +118,7 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
   ];
 }
 
-export type MatchType = 'active' | 'cold';
+export type MatchType = 'active' | 'hot' | 'cold';
 
 export interface LineMatch {
   line: InsuranceLineConfig;
@@ -107,11 +126,11 @@ export interface LineMatch {
 }
 
 /**
- * Determine which insurance line (and whether cold/active) a set of GoHighLevel
- * tags belongs to.
+ * Determine which insurance line (and which tier) a set of GoHighLevel tags
+ * belongs to.
  *
- * Active-client detection takes priority over cold-lead detection, and lines
- * are evaluated in the order returned by {@link getInsuranceLines}.
+ * Priority is active > hot > cold, evaluated across all lines in the order
+ * returned by {@link getInsuranceLines}.
  */
 export function matchInsuranceLine(
   tags: string[],
@@ -119,7 +138,7 @@ export function matchInsuranceLine(
 ): LineMatch | null {
   const lowerTags = tags.map((t) => t.toLowerCase().trim());
 
-  // 1. Active clients first (exact tag match) across all lines.
+  // 1. Active clients (exact tag match) across all lines.
   for (const line of lines) {
     const isActive = lowerTags.some((tag) => line.activeClientTags.includes(tag));
     if (isActive) {
@@ -127,7 +146,20 @@ export function matchInsuranceLine(
     }
   }
 
-  // 2. Cold leads (substring match) in line priority order.
+  // 2. Hot leads (substring match) for lines that define a hot tier.
+  for (const line of lines) {
+    if (!line.hotLeadMatchers || !line.hotLeadsBucketId) {
+      continue;
+    }
+    const isHot = lowerTags.some((tag) =>
+      line.hotLeadMatchers!.some((matcher) => tag.includes(matcher))
+    );
+    if (isHot) {
+      return { line, type: 'hot' };
+    }
+  }
+
+  // 3. Cold leads (substring match) in line priority order.
   for (const line of lines) {
     const isCold = lowerTags.some((tag) =>
       line.coldLeadMatchers.some((matcher) => tag.includes(matcher))

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -18,21 +18,25 @@
  * priority.
  */
 
-export type StateName = 'cold' | 'hot' | 'active';
+export type StateName = 'cold' | 'hot' | 'active' | 'winback';
 
 /**
  * Detection/priority ordering when a contact matches more than one state.
  * Lower number = higher priority. A contact that has accumulated several tags
- * resolves to the highest priority state, so: active > hot > cold.
+ * resolves to the highest priority state, so: active > winback > hot > cold.
  *
- * Hot beats cold so that a lead showing renewed buying intent (hot) is not
- * pulled back into the cold bucket just because an old cold tag is still
- * present. To move a lead back to cold, remove the hot tag in GoHighLevel.
+ * - Active is highest: a sold client stays sold.
+ * - Winback (lapsed/cancelled client to re-pursue) outranks cold/hot leads.
+ * - Hot beats cold so renewed buying intent isn't pulled back into cold.
+ *
+ * To move a contact down a state, remove the higher state's tag in
+ * GoHighLevel (e.g. remove the active tag when tagging a contact for winback).
  */
 export const STATE_PRIORITY: Record<StateName, number> = {
   active: 0,
-  hot: 1,
-  cold: 2,
+  winback: 1,
+  hot: 2,
+  cold: 3,
 };
 
 export interface LineState {
@@ -53,6 +57,12 @@ export interface LineState {
   removeTags: string[];
   /** Whether reaching this state marks the contact as a customer (excluded from cold syncs). */
   isCustomer: boolean;
+  /**
+   * When true, this state is applied even if the contact is already a known
+   * customer, and it resets the customer flag. Used for winback (re-pursuing a
+   * lapsed/cancelled client who was previously an active customer).
+   */
+  overridesCustomer?: boolean;
 }
 
 export interface InsuranceLineConfig {
@@ -72,6 +82,7 @@ export interface InsuranceLineConfig {
 export interface InsuranceLineEnv {
   ACA_COLD_LEADS_BUCKET_ID?: string;
   ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
+  ACA_WINBACK_BUCKET_ID?: string;
   AUTO_COLD_LEADS_BUCKET_ID?: string;
   AUTO_HOT_LEADS_BUCKET_ID?: string;
   AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;
@@ -108,6 +119,7 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
 
   const acaCold = pick(env.ACA_COLD_LEADS_BUCKET_ID, '11237');
   const acaActive = pick(env.ACA_ACTIVE_CLIENTS_BUCKET_ID, '11252');
+  const acaWinback = pick(env.ACA_WINBACK_BUCKET_ID, '11238');
 
   return [
     {
@@ -183,9 +195,26 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
           bucketId: acaActive,
           // CallTools tag (id 129315)
           tag: 'ACA Active Client',
-          removeBucketIds: [acaCold],
-          removeTags: ['ACA Cold Lead'],
+          // A re-sold client leaves the cold and winback buckets/tags.
+          removeBucketIds: [acaCold, acaWinback],
+          removeTags: ['ACA Cold Lead', 'winback – aca'],
           isCustomer: true,
+        },
+        {
+          name: 'winback',
+          // GHL trigger tag: "winback – aca" (lapsed/cancelled ACA client to re-pursue)
+          matchers: ['winback - aca', 'winback aca'],
+          bucketId: acaWinback,
+          // CallTools tag (id 132076) - note the en-dash to match the existing tag
+          tag: 'winback – aca',
+          // Past clients leave the cold + active buckets/tags so they only sit
+          // in the Win-Back queue.
+          removeBucketIds: [acaCold, acaActive],
+          removeTags: ['ACA Cold Lead', 'ACA Active Client'],
+          // Not a customer (we want to call them to re-sell), and override the
+          // existing customer flag set while they were an active client.
+          isCustomer: false,
+          overridesCustomer: true,
         },
       ],
     },

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -171,7 +171,8 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
           name: 'cold',
           matchers: ['cold lead', 'cold', 'new lead', 'prospect'],
           bucketId: acaCold,
-          tag: 'ACA Cold lead',
+          // CallTools tag (id 128365)
+          tag: 'ACA Cold Lead',
           removeBucketIds: [],
           removeTags: [],
           isCustomer: false,
@@ -180,9 +181,10 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
           name: 'active',
           matchers: ['aca active 2025', 'aca active 2026', 'aca active client'],
           bucketId: acaActive,
-          tag: 'ACA Active client',
+          // CallTools tag (id 129315)
+          tag: 'ACA Active Client',
           removeBucketIds: [acaCold],
-          removeTags: ['ACA Cold lead'],
+          removeTags: ['ACA Cold Lead'],
           isCustomer: true,
         },
       ],

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -116,35 +116,49 @@ export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] 
       states: [
         {
           name: 'hot',
-          // GHL tag: "auto – autoquote click"
-          matchers: ['auto - autoquote click', 'autoquote click', 'autoquote'],
+          // GHL trigger tag(s): "auto – autoquote click" or "Auto Insurance Hot Leads"
+          matchers: [
+            'auto - autoquote click',
+            'autoquote click',
+            'autoquote',
+            'auto insurance hot leads',
+            'auto insurance hot',
+          ],
           bucketId: autoHot,
-          tag: 'Auto Hot lead',
+          // CallTools tag (id 142724)
+          tag: 'Auto Insurance Hot Leads',
           // Leads can move cold <-> hot, so going hot removes the cold bucket/tag.
           removeBucketIds: [autoCold],
-          removeTags: ['Auto Cold lead'],
+          removeTags: ['Auto Insurance Cold Leads'],
           isCustomer: false,
         },
         {
           name: 'cold',
-          // GHL tag: "cold_lead_auto"
-          matchers: ['cold_lead_auto', 'cold lead auto'],
+          // GHL trigger tag(s): "cold_lead_auto" or "Auto Insurance Cold Leads"
+          matchers: [
+            'cold_lead_auto',
+            'cold lead auto',
+            'auto insurance cold leads',
+            'auto insurance cold',
+          ],
           bucketId: autoCold,
-          tag: 'Auto Cold lead',
+          // CallTools tag (id 142725)
+          tag: 'Auto Insurance Cold Leads',
           // Adding to cold removes the contact from the hot bucket/tag.
           removeBucketIds: [autoHot],
-          removeTags: ['Auto Hot lead'],
+          removeTags: ['Auto Insurance Hot Leads'],
           isCustomer: false,
         },
         {
           name: 'active',
-          // GHL tag: "auto – active"
+          // GHL trigger tag: "auto – active"
           matchers: ['auto - active', 'auto active', 'auto active client', 'auto active 2025', 'auto active 2026'],
           bucketId: autoActive,
-          tag: 'Auto Active client',
+          // CallTools tag (id 142754) - note the en-dash to match the existing tag
+          tag: 'auto – active',
           // Active removes the contact from both cold and hot.
           removeBucketIds: [autoCold, autoHot],
-          removeTags: ['Auto Cold lead', 'Auto Hot lead'],
+          removeTags: ['Auto Insurance Cold Leads', 'Auto Insurance Hot Leads'],
           isCustomer: true,
         },
       ],

--- a/src/config/insuranceLines.ts
+++ b/src/config/insuranceLines.ts
@@ -1,0 +1,141 @@
+/**
+ * Insurance line (vertical) configuration.
+ *
+ * The integration syncs contacts from GoHighLevel into CallTools. Different
+ * insurance products ("lines of business") are routed to different CallTools
+ * buckets and tagged differently so each campaign stays isolated.
+ *
+ * Each line defines:
+ *  - how to detect cold leads / active clients from GoHighLevel tags
+ *  - which CallTools bucket cold leads and active clients land in
+ *  - which CallTools tags are applied for cold leads and active clients
+ *
+ * Lines are evaluated in array order, so more specific lines (e.g. Auto, whose
+ * tags also contain generic words like "cold") MUST come before more generic
+ * lines (ACA) to avoid mis-routing.
+ */
+
+export interface InsuranceLineConfig {
+  /** Stable identifier for the line, e.g. "aca" or "auto". */
+  key: string;
+  /** Human friendly label used in logs / responses. */
+  label: string;
+  /**
+   * GoHighLevel tags (lowercase) that mark a contact as an active/sold client
+   * for this line. Matched exactly (case-insensitive).
+   */
+  activeClientTags: string[];
+  /**
+   * GoHighLevel tag fragments (lowercase) that mark a contact as a cold lead
+   * for this line. Matched as a substring (case-insensitive).
+   */
+  coldLeadMatchers: string[];
+  /** CallTools bucket/list ID that cold leads are added to. */
+  coldLeadsBucketId: string;
+  /** CallTools bucket/list ID that active clients are moved to. */
+  activeClientsBucketId: string;
+  /** CallTools tag applied to cold leads for this line. */
+  coldLeadTag: string;
+  /** CallTools tag applied to active clients for this line. */
+  activeClientTag: string;
+}
+
+/**
+ * Minimal shape of the environment values consumed here. Bucket IDs are
+ * overridable via environment variables so they can differ per deployment
+ * without code changes.
+ */
+export interface InsuranceLineEnv {
+  ACA_COLD_LEADS_BUCKET_ID?: string;
+  ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
+  AUTO_COLD_LEADS_BUCKET_ID?: string;
+  AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;
+}
+
+function pick(value: string | undefined, fallback: string): string {
+  const trimmed = (value || '').trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+/**
+ * Build the list of insurance lines for the current environment.
+ *
+ * NOTE: order matters. Auto is listed first because its cold-lead tags (e.g.
+ * "auto cold lead") also contain generic words like "cold" that the ACA line
+ * matches. Evaluating Auto first guarantees Auto contacts are not swept into
+ * the ACA bucket.
+ */
+export function getInsuranceLines(env: InsuranceLineEnv): InsuranceLineConfig[] {
+  return [
+    {
+      key: 'auto',
+      label: 'Auto Insurance',
+      activeClientTags: ['auto active 2025', 'auto active 2026', 'auto active client'],
+      coldLeadMatchers: [
+        'auto cold lead',
+        'auto cold',
+        'auto lead',
+        'auto prospect',
+        'auto insurance',
+        'auto new lead',
+      ],
+      // Configure these via env vars; no safe default exists for Auto buckets.
+      coldLeadsBucketId: pick(env.AUTO_COLD_LEADS_BUCKET_ID, ''),
+      activeClientsBucketId: pick(env.AUTO_ACTIVE_CLIENTS_BUCKET_ID, ''),
+      coldLeadTag: 'Auto Cold lead',
+      activeClientTag: 'Auto Active client',
+    },
+    {
+      key: 'aca',
+      label: 'ACA / Health Insurance',
+      activeClientTags: ['aca active 2025', 'aca active 2026', 'aca active client'],
+      coldLeadMatchers: ['cold lead', 'cold', 'new lead', 'prospect'],
+      // Preserve the historical hardcoded ACA bucket IDs as defaults.
+      coldLeadsBucketId: pick(env.ACA_COLD_LEADS_BUCKET_ID, '11237'),
+      activeClientsBucketId: pick(env.ACA_ACTIVE_CLIENTS_BUCKET_ID, '11252'),
+      coldLeadTag: 'ACA Cold lead',
+      activeClientTag: 'ACA Active client',
+    },
+  ];
+}
+
+export type MatchType = 'active' | 'cold';
+
+export interface LineMatch {
+  line: InsuranceLineConfig;
+  type: MatchType;
+}
+
+/**
+ * Determine which insurance line (and whether cold/active) a set of GoHighLevel
+ * tags belongs to.
+ *
+ * Active-client detection takes priority over cold-lead detection, and lines
+ * are evaluated in the order returned by {@link getInsuranceLines}.
+ */
+export function matchInsuranceLine(
+  tags: string[],
+  lines: InsuranceLineConfig[]
+): LineMatch | null {
+  const lowerTags = tags.map((t) => t.toLowerCase().trim());
+
+  // 1. Active clients first (exact tag match) across all lines.
+  for (const line of lines) {
+    const isActive = lowerTags.some((tag) => line.activeClientTags.includes(tag));
+    if (isActive) {
+      return { line, type: 'active' };
+    }
+  }
+
+  // 2. Cold leads (substring match) in line priority order.
+  for (const line of lines) {
+    const isCold = lowerTags.some((tag) =>
+      line.coldLeadMatchers.some((matcher) => tag.includes(matcher))
+    );
+    if (isCold) {
+      return { line, type: 'cold' };
+    }
+  }
+
+  return null;
+}

--- a/src/endpoints/sync/syncTrigger.ts
+++ b/src/endpoints/sync/syncTrigger.ts
@@ -2,6 +2,7 @@ import { OpenAPIRoute, Str } from 'chanfana';
 import { z } from 'zod';
 import { HandleArgs } from '../../types';
 import { ContactSyncService } from '../../services/contactSyncService';
+import { getInsuranceLines } from '../../config/insuranceLines';
 
 export class SyncTrigger extends OpenAPIRoute<HandleArgs> {
   schema = {
@@ -68,7 +69,8 @@ export class SyncTrigger extends OpenAPIRoute<HandleArgs> {
         env.GHL_API_KEY,
         env.CALLTOOLS_API_KEY,
         env.CALLTOOLS_BASE_URL,
-        env.DB
+        env.DB,
+        getInsuranceLines(env)
       );
 
       // Run sync

--- a/src/endpoints/webhook/ghlWebhook.ts
+++ b/src/endpoints/webhook/ghlWebhook.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { HandleArgs } from '../../types';
 import { ContactSyncService } from '../../services/contactSyncService';
 import { WebhookVerificationService } from '../../services/webhookVerification';
+import { getInsuranceLines } from '../../config/insuranceLines';
 
 // GoHighLevel webhook payload schema - flexible to handle different formats
 const GHLWebhookSchema = z.object({
@@ -160,7 +161,8 @@ export class GHLWebhook extends OpenAPIRoute<HandleArgs> {
         env.GHL_API_KEY,
         env.CALLTOOLS_API_KEY,
         env.CALLTOOLS_BASE_URL,
-        env.DB
+        env.DB,
+        getInsuranceLines(env)
       );
 
       // Sync the specific contact, passing webhook data to avoid API call

--- a/src/endpoints/webhook/ghlWorkflow.ts
+++ b/src/endpoints/webhook/ghlWorkflow.ts
@@ -2,6 +2,7 @@ import { OpenAPIRoute } from 'chanfana';
 import { z } from 'zod';
 import { HandleArgs } from '../../types';
 import { ContactSyncService } from '../../services/contactSyncService';
+import { getInsuranceLines } from '../../config/insuranceLines';
 
 // GHL Workflow payload schema - flexible to handle different formats
 const GHLWorkflowSchema = z.object({
@@ -132,7 +133,8 @@ export class GHLWorkflow extends OpenAPIRoute<HandleArgs> {
         env.GHL_API_KEY,
         env.CALLTOOLS_API_KEY,
         env.CALLTOOLS_BASE_URL,
-        env.DB
+        env.DB,
+        getInsuranceLines(env)
       );
 
       // Sync the specific contact

--- a/src/services/contactSyncService.ts
+++ b/src/services/contactSyncService.ts
@@ -105,6 +105,14 @@ export class ContactSyncService {
         return await this.syncActiveClient(ghlContact, match.line);
       }
 
+      // Hot leads (engaged but not yet sold) - promote to the line's hot bucket
+      if (match && match.type === 'hot') {
+        console.log(
+          `Contact ${ghlContactId} matched hot lead for line "${match.line.label}"`
+        );
+        return await this.promoteContact(ghlContact, match.line, 'hot');
+      }
+
       // Generic customer exclusion (not tied to a specific line). A contact
       // flagged as a generic customer/won/purchased lead should never be dialed
       // as a cold lead.
@@ -192,9 +200,7 @@ export class ContactSyncService {
   }
 
   /**
-   * Sync an active client to CallTools.
-   * Handles contacts whose GoHighLevel tags mark them as an active/sold client
-   * for a given insurance line (e.g. "ACA Active 2025", "Auto Active 2026").
+   * Convenience wrapper: promote a contact to the active-client tier.
    */
   private async syncActiveClient(
     ghlContact: GHLContact,
@@ -206,24 +212,58 @@ export class ContactSyncService {
     bucket_id: string | null;
     error?: string;
   }> {
+    return this.promoteContact(ghlContact, line, 'active');
+  }
+
+  /**
+   * Promote a contact into a higher tier (hot lead or active client) for a line.
+   *
+   * The contact is created/updated in CallTools, added to the target tier's
+   * bucket/tag, and removed from the buckets/tags of all lower tiers. Active
+   * clients are additionally marked as customers in the database (and excluded
+   * from future cold-lead syncs); hot leads are not.
+   */
+  private async promoteContact(
+    ghlContact: GHLContact,
+    line: InsuranceLineConfig,
+    tier: 'hot' | 'active'
+  ): Promise<{
+    success: boolean;
+    contact_id: string;
+    action: 'synced' | 'updated' | 'excluded' | 'failed';
+    bucket_id: string | null;
+    error?: string;
+  }> {
     try {
-      const ACTIVE_CLIENTS_BUCKET_ID = line.activeClientsBucketId;
-      const COLD_LEADS_BUCKET_ID = line.coldLeadsBucketId;
-      const ACTIVE_CLIENT_TAG = line.activeClientTag;
-      const COLD_LEAD_TAG = line.coldLeadTag;
+      const isActive = tier === 'active';
+      const tierLabel = isActive ? 'active client' : 'hot lead';
 
-      console.log(`Processing active client for line "${line.label}": ${ghlContact.id}`);
+      // Resolve the target bucket/tag and the lower tiers to clean up.
+      const targetBucketId = isActive ? line.activeClientsBucketId : (line.hotLeadsBucketId || '');
+      const targetTag = isActive ? line.activeClientTag : (line.hotLeadTag || '');
 
-      if (!ACTIVE_CLIENTS_BUCKET_ID) {
+      // Lower-tier buckets/tags to remove the contact from on promotion.
+      const removeBucketIds: string[] = [];
+      const removeTags: string[] = [];
+      if (line.coldLeadsBucketId) removeBucketIds.push(line.coldLeadsBucketId);
+      if (line.coldLeadTag) removeTags.push(line.coldLeadTag);
+      if (isActive) {
+        if (line.hotLeadsBucketId) removeBucketIds.push(line.hotLeadsBucketId);
+        if (line.hotLeadTag) removeTags.push(line.hotLeadTag);
+      }
+
+      console.log(`Processing ${tierLabel} for line "${line.label}": ${ghlContact.id}`);
+
+      if (!targetBucketId || !targetTag) {
         console.error(
-          `No active clients bucket configured for line "${line.label}", cannot sync ${ghlContact.id}`
+          `No ${tierLabel} bucket configured for line "${line.label}", cannot sync ${ghlContact.id}`
         );
         return {
           success: false,
           contact_id: ghlContact.id,
           action: 'failed',
           bucket_id: null,
-          error: `No active clients bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
+          error: `No ${tierLabel} bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
         };
       }
 
@@ -246,7 +286,7 @@ export class ContactSyncService {
         last_name: ghlContact.lastName || '',
         mobile_phone_number: phone,
         personal_email_address: ghlContact.email || '',
-        bucket_id: ACTIVE_CLIENTS_BUCKET_ID,
+        bucket_id: targetBucketId,
       };
 
       // Check if contact already exists in CallTools (search by phone)
@@ -255,122 +295,78 @@ export class ContactSyncService {
         phone
       );
 
-      if (existingCallToolsContact) {
-        console.log(`Updating existing contact ${ghlContact.id} as active client`);
-        
-        // Update contact details
-        await this.callToolsClient.updateContact(
-          existingCallToolsContact.id,
-          callToolsContact
-        );
+      const contactId = existingCallToolsContact ? existingCallToolsContact.id : null;
+      const isUpdate = contactId !== null;
 
-        // Add to Active Clients bucket
-        await this.callToolsClient.addContactToBucket(
-          existingCallToolsContact.id,
-          ACTIVE_CLIENTS_BUCKET_ID
-        );
-        console.log(`Added contact to Active Clients bucket (${ACTIVE_CLIENTS_BUCKET_ID})`);
-
-        // Remove from Cold Leads bucket
-        if (COLD_LEADS_BUCKET_ID) {
-          try {
-            await this.callToolsClient.removeContactFromBucket(
-              existingCallToolsContact.id,
-              COLD_LEADS_BUCKET_ID
-            );
-            console.log(`Removed contact from Cold Leads bucket (${COLD_LEADS_BUCKET_ID})`);
-          } catch (error) {
-            console.log(`Could not remove from Cold Leads bucket (may not be in it):`, error);
-          }
-        }
-
-        // Add active client tag
-        await this.callToolsClient.addTagToContact(
-          existingCallToolsContact.id,
-          ACTIVE_CLIENT_TAG
-        );
-        console.log(`Added "${ACTIVE_CLIENT_TAG}" tag`);
-
-        // Remove cold lead tag if it exists
-        try {
-          await this.callToolsClient.removeTagFromContact(
-            existingCallToolsContact.id,
-            COLD_LEAD_TAG
-          );
-          console.log(`Removed "${COLD_LEAD_TAG}" tag`);
-        } catch (error) {
-          console.log(`Could not remove "${COLD_LEAD_TAG}" tag (may not exist):`, error);
-        }
-
-        // Update sync record
-        await this.updateSyncRecord(ghlContact.id, {
-          calltools_contact_id: existingCallToolsContact.id,
-          first_name: callToolsContact.first_name,
-          last_name: callToolsContact.last_name,
-          phone: callToolsContact.mobile_phone_number,
-          email: callToolsContact.email,
-          sync_status: 'synced',
-          last_sync_at: new Date().toISOString(),
-          error_message: null,
-        });
-
-        // Mark as customer in our database
-        await this.markAsCustomer(ghlContact.id);
-
-        console.log(`Successfully updated contact ${ghlContact.id} as active client`);
-
-        return {
-          success: true,
-          contact_id: ghlContact.id,
-          action: 'updated',
-          bucket_id: ACTIVE_CLIENTS_BUCKET_ID,
-        };
+      let resolvedContactId: string;
+      if (isUpdate) {
+        console.log(`Updating existing contact ${ghlContact.id} as ${tierLabel}`);
+        await this.callToolsClient.updateContact(contactId!, callToolsContact);
+        resolvedContactId = contactId!;
       } else {
-        console.log(`Creating new contact ${ghlContact.id} as active client`);
-
-        // Create new contact
+        console.log(`Creating new contact ${ghlContact.id} as ${tierLabel}`);
         const createdContact = await this.callToolsClient.createContact(callToolsContact);
         console.log(`Created contact with ID: ${createdContact.id}`);
-
-        // Add to Active Clients bucket
-        await this.callToolsClient.addContactToBucket(
-          createdContact.id,
-          ACTIVE_CLIENTS_BUCKET_ID
-        );
-        console.log(`Added contact to Active Clients bucket (${ACTIVE_CLIENTS_BUCKET_ID})`);
-
-        // Add active client tag
-        await this.callToolsClient.addTagToContact(
-          createdContact.id,
-          ACTIVE_CLIENT_TAG
-        );
-        console.log(`Added "${ACTIVE_CLIENT_TAG}" tag`);
-
-        // Create sync record
-        await this.createOrUpdateSyncRecord({
-          ghl_contact_id: ghlContact.id,
-          calltools_contact_id: createdContact.id,
-          first_name: callToolsContact.first_name,
-          last_name: callToolsContact.last_name || null,
-          phone: callToolsContact.mobile_phone_number,
-          email: callToolsContact.email || null,
-          sync_status: 'synced',
-          last_sync_at: new Date().toISOString(),
-          error_message: null,
-          is_customer: 1, // Mark as customer
-        });
-
-        console.log(`Successfully created contact ${ghlContact.id} as active client`);
-
-        return {
-          success: true,
-          contact_id: ghlContact.id,
-          action: 'synced',
-          bucket_id: ACTIVE_CLIENTS_BUCKET_ID,
-        };
+        resolvedContactId = createdContact.id;
       }
+
+      // Add to the target tier bucket
+      await this.callToolsClient.addContactToBucket(resolvedContactId, targetBucketId);
+      console.log(`Added contact to ${tierLabel} bucket (${targetBucketId})`);
+
+      // Add the target tier tag
+      await this.callToolsClient.addTagToContact(resolvedContactId, targetTag);
+      console.log(`Added "${targetTag}" tag`);
+
+      // Remove from lower-tier buckets
+      for (const bucketId of removeBucketIds) {
+        try {
+          await this.callToolsClient.removeContactFromBucket(resolvedContactId, bucketId);
+          console.log(`Removed contact from lower-tier bucket (${bucketId})`);
+        } catch (error) {
+          console.log(`Could not remove from bucket ${bucketId} (may not be in it):`, error);
+        }
+      }
+
+      // Remove lower-tier tags
+      for (const tag of removeTags) {
+        try {
+          await this.callToolsClient.removeTagFromContact(resolvedContactId, tag);
+          console.log(`Removed "${tag}" tag`);
+        } catch (error) {
+          console.log(`Could not remove "${tag}" tag (may not exist):`, error);
+        }
+      }
+
+      // Update database
+      await this.createOrUpdateSyncRecord({
+        ghl_contact_id: ghlContact.id,
+        calltools_contact_id: resolvedContactId,
+        first_name: callToolsContact.first_name,
+        last_name: callToolsContact.last_name || null,
+        phone: callToolsContact.mobile_phone_number || null,
+        email: callToolsContact.email || null,
+        sync_status: 'synced',
+        last_sync_at: new Date().toISOString(),
+        error_message: null,
+        is_customer: isActive ? 1 : 0,
+      });
+
+      // Active clients are excluded from future cold syncs
+      if (isActive) {
+        await this.markAsCustomer(ghlContact.id);
+      }
+
+      console.log(`Successfully ${isUpdate ? 'updated' : 'created'} contact ${ghlContact.id} as ${tierLabel}`);
+
+      return {
+        success: true,
+        contact_id: ghlContact.id,
+        action: isUpdate ? 'updated' : 'synced',
+        bucket_id: targetBucketId,
+      };
     } catch (error) {
-      console.error(`Error syncing active client ${ghlContact.id}:`, error);
+      console.error(`Error syncing ${tier} for ${ghlContact.id}:`, error);
       return {
         success: false,
         contact_id: ghlContact.id,
@@ -418,16 +414,19 @@ export class ContactSyncService {
         result.total_processed++;
 
         try {
-          if (match.type === 'active') {
-            const activeResult = await this.syncActiveClient(ghlContact, match.line);
-            if (activeResult.action === 'synced') {
+          if (match.type === 'active' || match.type === 'hot') {
+            const promoteResult =
+              match.type === 'active'
+                ? await this.syncActiveClient(ghlContact, match.line)
+                : await this.promoteContact(ghlContact, match.line, 'hot');
+            if (promoteResult.action === 'synced') {
               result.synced++;
-            } else if (activeResult.action === 'updated') {
+            } else if (promoteResult.action === 'updated') {
               result.updated++;
-            } else if (activeResult.action === 'failed') {
+            } else if (promoteResult.action === 'failed') {
               result.failed++;
-              if (activeResult.error) {
-                result.errors.push({ contact_id: ghlContact.id, error: activeResult.error });
+              if (promoteResult.error) {
+                result.errors.push({ contact_id: ghlContact.id, error: promoteResult.error });
               }
             }
             continue;
@@ -577,7 +576,7 @@ export class ContactSyncService {
           calltools_contact_id: createdContact.id,
           first_name: callToolsContact.first_name,
           last_name: callToolsContact.last_name || null,
-          phone: callToolsContact.mobile_phone_number,
+          phone: callToolsContact.mobile_phone_number || null,
           email: callToolsContact.email || null,
           sync_status: 'synced',
           last_sync_at: new Date().toISOString(),

--- a/src/services/contactSyncService.ts
+++ b/src/services/contactSyncService.ts
@@ -1,5 +1,10 @@
 import { GoHighLevelClient, GHLContact } from '../clients/gohighlevel';
 import { CallToolsClient, CallToolsContact } from '../clients/calltools';
+import {
+  InsuranceLineConfig,
+  getInsuranceLines,
+  matchInsuranceLine,
+} from '../config/insuranceLines';
 
 export interface SyncResult {
   total_processed: number;
@@ -35,16 +40,21 @@ export class ContactSyncService {
   private ghlClient: GoHighLevelClient;
   private callToolsClient: CallToolsClient;
   private db: D1Database;
+  private lines: InsuranceLineConfig[];
 
   constructor(
     ghlApiKey: string,
     callToolsApiKey: string,
     callToolsBaseUrl: string | undefined,
-    db: D1Database
+    db: D1Database,
+    lines?: InsuranceLineConfig[]
   ) {
     this.ghlClient = new GoHighLevelClient(ghlApiKey);
     this.callToolsClient = new CallToolsClient(callToolsApiKey, callToolsBaseUrl);
     this.db = db;
+    // Fall back to env-less defaults (ACA buckets preserved, Auto unconfigured)
+    // so existing call sites keep working even if no lines are supplied.
+    this.lines = lines && lines.length > 0 ? lines : getInsuranceLines({});
   }
 
   /**
@@ -59,10 +69,6 @@ export class ContactSyncService {
     error?: string;
   }> {
     try {
-      // Use the Cold Leads bucket ID
-      const bucketId = '11237';
-      console.log(`Using Cold Leads bucket ID: ${bucketId}`);
-
       // Use webhook data if provided, otherwise fetch from GoHighLevel
       let ghlContact: any;
       if (webhookContactData) {
@@ -84,31 +90,32 @@ export class ContactSyncService {
       }
 
       // Check tags
-      const tags = Array.isArray(ghlContact.tags) 
-        ? (ghlContact.tags || []).map((t: string) => t.toLowerCase())
+      const tags: string[] = Array.isArray(ghlContact.tags)
+        ? (ghlContact.tags as string[]).map((t) => String(t).toLowerCase())
         : [];
-      
-      // Check if contact has "ACA Active 2025" or "ACA Active 2026" tag
-      const isActiveClient = tags.some(tag => 
-        tag === 'aca active 2025' ||
-        tag === 'aca active 2026'
-      );
 
-      if (isActiveClient) {
-        // Handle active client sync
-        return await this.syncActiveClient(ghlContact);
+      // Determine which insurance line (and cold vs active) this contact maps to
+      const match = matchInsuranceLine(tags, this.lines);
+
+      // Active clients take priority across all lines (ACA, Auto, ...)
+      if (match && match.type === 'active') {
+        console.log(
+          `Contact ${ghlContactId} matched active client for line "${match.line.label}"`
+        );
+        return await this.syncActiveClient(ghlContact, match.line);
       }
 
-      // Check if contact is a customer (but not specifically ACA Active)
-      const isCustomer = tags.some(tag => 
-        tag.includes('customer') || 
+      // Generic customer exclusion (not tied to a specific line). A contact
+      // flagged as a generic customer/won/purchased lead should never be dialed
+      // as a cold lead.
+      const isCustomer = tags.some(tag =>
+        tag.includes('customer') ||
         tag.includes('client') ||
         tag.includes('won') ||
         tag.includes('purchased')
       );
 
       if (isCustomer) {
-        // Mark as customer and exclude
         console.log(`Contact ${ghlContactId} excluded: contains customer/client tags`);
         await this.markAsCustomer(ghlContactId);
         return {
@@ -119,26 +126,35 @@ export class ContactSyncService {
         };
       }
 
-      // Check if contact has "cold lead" tag
-      const isCold = tags.some(tag => 
-        tag === 'cold lead' ||
-        tag.includes('cold') ||
-        tag.includes('new lead') ||
-        tag.includes('prospect')
-      );
-
-      if (!isCold) {
-        console.log(`Contact ${ghlContactId} excluded: does not have cold lead or active client tag`);
+      if (!match || match.type !== 'cold') {
+        console.log(`Contact ${ghlContactId} excluded: does not match any cold lead or active client line`);
         return {
           success: true,
           contact_id: ghlContactId,
           action: 'excluded',
           bucket_id: null,
-          error: 'Contact does not have cold lead or active client tag',
+          error: 'Contact does not match any cold lead or active client line',
         };
       }
 
-      console.log(`Contact ${ghlContactId} is a cold lead, proceeding to sync to CallTools`);
+      const line = match.line;
+
+      if (!line.coldLeadsBucketId) {
+        console.error(
+          `Contact ${ghlContactId} matched line "${line.label}" cold lead, but no cold leads bucket is configured`
+        );
+        return {
+          success: false,
+          contact_id: ghlContactId,
+          action: 'failed',
+          bucket_id: null,
+          error: `No cold leads bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
+        };
+      }
+
+      console.log(
+        `Contact ${ghlContactId} is a "${line.label}" cold lead, syncing to CallTools bucket ${line.coldLeadsBucketId}`
+      );
 
       // Sync the contact
       const result: SyncResult = {
@@ -147,12 +163,12 @@ export class ContactSyncService {
         updated: 0,
         excluded_customers: 0,
         failed: 0,
-        bucket_name: 'Cold Leads',
-        bucket_id: bucketId,
+        bucket_name: `${line.label} Cold Leads`,
+        bucket_id: line.coldLeadsBucketId,
         errors: [],
       };
 
-      await this.syncContact(ghlContact, result, bucketId);
+      await this.syncContact(ghlContact, result, line);
 
       const action = result.synced > 0 ? 'synced' : result.updated > 0 ? 'updated' : 'failed';
 
@@ -160,7 +176,7 @@ export class ContactSyncService {
         success: result.failed === 0,
         contact_id: ghlContactId,
         action,
-        bucket_id: bucketId,
+        bucket_id: line.coldLeadsBucketId,
         error: result.errors[0]?.error,
       };
     } catch (error) {
@@ -176,10 +192,14 @@ export class ContactSyncService {
   }
 
   /**
-   * Sync an active client to CallTools
-   * Handles contacts with "ACA Active 2025" or "ACA Active 2026" tags
+   * Sync an active client to CallTools.
+   * Handles contacts whose GoHighLevel tags mark them as an active/sold client
+   * for a given insurance line (e.g. "ACA Active 2025", "Auto Active 2026").
    */
-  private async syncActiveClient(ghlContact: GHLContact): Promise<{
+  private async syncActiveClient(
+    ghlContact: GHLContact,
+    line: InsuranceLineConfig
+  ): Promise<{
     success: boolean;
     contact_id: string;
     action: 'synced' | 'updated' | 'excluded' | 'failed';
@@ -187,12 +207,25 @@ export class ContactSyncService {
     error?: string;
   }> {
     try {
-      const ACTIVE_CLIENTS_BUCKET_ID = '11252';
-      const COLD_LEADS_BUCKET_ID = '11237';
-      const ACTIVE_CLIENT_TAG = 'ACA Active client';
-      const COLD_LEAD_TAG = 'ACA Cold lead';
+      const ACTIVE_CLIENTS_BUCKET_ID = line.activeClientsBucketId;
+      const COLD_LEADS_BUCKET_ID = line.coldLeadsBucketId;
+      const ACTIVE_CLIENT_TAG = line.activeClientTag;
+      const COLD_LEAD_TAG = line.coldLeadTag;
 
-      console.log(`Processing active client: ${ghlContact.id}`);
+      console.log(`Processing active client for line "${line.label}": ${ghlContact.id}`);
+
+      if (!ACTIVE_CLIENTS_BUCKET_ID) {
+        console.error(
+          `No active clients bucket configured for line "${line.label}", cannot sync ${ghlContact.id}`
+        );
+        return {
+          success: false,
+          contact_id: ghlContact.id,
+          action: 'failed',
+          bucket_id: null,
+          error: `No active clients bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
+        };
+      }
 
       // Check if contact has phone number
       const phone = ghlContact.phone || '';
@@ -239,24 +272,26 @@ export class ContactSyncService {
         console.log(`Added contact to Active Clients bucket (${ACTIVE_CLIENTS_BUCKET_ID})`);
 
         // Remove from Cold Leads bucket
-        try {
-          await this.callToolsClient.removeContactFromBucket(
-            existingCallToolsContact.id,
-            COLD_LEADS_BUCKET_ID
-          );
-          console.log(`Removed contact from Cold Leads bucket (${COLD_LEADS_BUCKET_ID})`);
-        } catch (error) {
-          console.log(`Could not remove from Cold Leads bucket (may not be in it):`, error);
+        if (COLD_LEADS_BUCKET_ID) {
+          try {
+            await this.callToolsClient.removeContactFromBucket(
+              existingCallToolsContact.id,
+              COLD_LEADS_BUCKET_ID
+            );
+            console.log(`Removed contact from Cold Leads bucket (${COLD_LEADS_BUCKET_ID})`);
+          } catch (error) {
+            console.log(`Could not remove from Cold Leads bucket (may not be in it):`, error);
+          }
         }
 
-        // Add "ACA Active client" tag
+        // Add active client tag
         await this.callToolsClient.addTagToContact(
           existingCallToolsContact.id,
           ACTIVE_CLIENT_TAG
         );
         console.log(`Added "${ACTIVE_CLIENT_TAG}" tag`);
 
-        // Remove "ACA Cold lead" tag if it exists
+        // Remove cold lead tag if it exists
         try {
           await this.callToolsClient.removeTagFromContact(
             existingCallToolsContact.id,
@@ -304,7 +339,7 @@ export class ContactSyncService {
         );
         console.log(`Added contact to Active Clients bucket (${ACTIVE_CLIENTS_BUCKET_ID})`);
 
-        // Add "ACA Active client" tag
+        // Add active client tag
         await this.callToolsClient.addTagToContact(
           createdContact.id,
           ACTIVE_CLIENT_TAG
@@ -347,37 +382,80 @@ export class ContactSyncService {
   }
 
   /**
-   * Main sync function - syncs cold contacts from GHL to CallTools
+   * Main batch sync function - syncs cold contacts from GHL to CallTools across
+   * every configured insurance line (ACA, Auto, ...).
+   *
+   * Each contact is routed to the correct line bucket/tag based on its tags.
+   * Active clients are also handled so the nightly batch can correct any missed
+   * webhooks.
    */
   async syncColdContacts(): Promise<SyncResult> {
-    const bucketName = 'Cold Leads';
     const result: SyncResult = {
       total_processed: 0,
       synced: 0,
       updated: 0,
       excluded_customers: 0,
       failed: 0,
-      bucket_name: bucketName,
+      bucket_name: 'Multiple (per line)',
       bucket_id: null,
       errors: [],
     };
 
     try {
-      // Use the Cold Leads bucket ID
-      const bucketId = '11237';
-      result.bucket_id = bucketId;
-      console.log(`Using Cold Leads bucket ID: ${bucketId}`);
+      console.log('Fetching contacts from GoHighLevel for batch sync...');
+      const allContacts = await this.ghlClient.getAllContacts();
+      console.log(`Fetched ${allContacts.length} contacts from GoHighLevel`);
 
-      console.log('Fetching cold contacts from GoHighLevel...');
-      const coldContacts = await this.ghlClient.getColdContactsExcludingCustomers();
-      result.total_processed = coldContacts.length;
-      
-      console.log(`Found ${coldContacts.length} cold contacts to process`);
+      // Route each contact to the correct insurance line
+      for (const ghlContact of allContacts) {
+        const tags = (ghlContact.tags || []).map((t) => t.toLowerCase());
+        const match = matchInsuranceLine(tags, this.lines);
 
-      // Process each contact
-      for (const ghlContact of coldContacts) {
+        if (!match) {
+          continue; // Not a cold lead or active client for any line
+        }
+
+        result.total_processed++;
+
         try {
-          await this.syncContact(ghlContact, result, bucketId || '');
+          if (match.type === 'active') {
+            const activeResult = await this.syncActiveClient(ghlContact, match.line);
+            if (activeResult.action === 'synced') {
+              result.synced++;
+            } else if (activeResult.action === 'updated') {
+              result.updated++;
+            } else if (activeResult.action === 'failed') {
+              result.failed++;
+              if (activeResult.error) {
+                result.errors.push({ contact_id: ghlContact.id, error: activeResult.error });
+              }
+            }
+            continue;
+          }
+
+          // Cold lead: skip generic customers (won/purchased) that aren't active
+          const isCustomer = tags.some(
+            (tag) =>
+              tag.includes('customer') ||
+              tag.includes('won') ||
+              tag.includes('purchased')
+          );
+          if (isCustomer) {
+            result.excluded_customers++;
+            await this.markAsCustomer(ghlContact.id);
+            continue;
+          }
+
+          if (!match.line.coldLeadsBucketId) {
+            result.failed++;
+            result.errors.push({
+              contact_id: ghlContact.id,
+              error: `No cold leads bucket configured for line "${match.line.label}"`,
+            });
+            continue;
+          }
+
+          await this.syncContact(ghlContact, result, match.line);
         } catch (error) {
           result.failed++;
           result.errors.push({
@@ -388,7 +466,7 @@ export class ContactSyncService {
         }
       }
 
-      console.log('Sync completed:', result);
+      console.log('Batch sync completed:', result);
       return result;
     } catch (error) {
       console.error('Error during sync:', error);
@@ -397,9 +475,12 @@ export class ContactSyncService {
   }
 
   /**
-   * Sync a single contact
+   * Sync a single cold-lead contact into the bucket/tag for its insurance line.
    */
-  private async syncContact(ghlContact: GHLContact, result: SyncResult, bucketId: string): Promise<void> {
+  private async syncContact(ghlContact: GHLContact, result: SyncResult, line: InsuranceLineConfig): Promise<void> {
+    const bucketId = line.coldLeadsBucketId;
+    const coldLeadTag = line.coldLeadTag;
+
     // Check if contact is already tracked in our database
     const existingRecord = await this.getSyncedContact(ghlContact.id);
 
@@ -426,7 +507,7 @@ export class ContactSyncService {
       last_name: ghlContact.lastName || '',
       mobile_phone_number: phone,
       personal_email_address: ghlContact.email || '',
-      bucket_id: bucketId, // Assign to Cold Leads bucket
+      bucket_id: bucketId, // Assign to this line's Cold Leads bucket
       // Don't send tags in create payload - add them separately after creation
     };
 
@@ -453,10 +534,10 @@ export class ContactSyncService {
           console.log(`Added contact ${existingCallToolsContact.id} to bucket ${bucketId}`);
         }
         
-        // Add ACA Cold lead tag
+        // Add cold lead tag for this line
         await this.callToolsClient.addTagToContact(
           existingCallToolsContact.id,
-          'ACA Cold lead'
+          coldLeadTag
         );
         
         await this.updateSyncRecord(ghlContact.id, {
@@ -471,7 +552,7 @@ export class ContactSyncService {
         });
         
         result.updated++;
-        console.log(`Updated contact ${ghlContact.id} in CallTools and added to Cold Leads bucket`);
+        console.log(`Updated contact ${ghlContact.id} in CallTools and added to ${line.label} Cold Leads bucket`);
       } else {
         // Create new contact
         const createdContact = await this.callToolsClient.createContact(callToolsContact);
@@ -485,10 +566,10 @@ export class ContactSyncService {
           console.log(`Added contact ${createdContact.id} to bucket ${bucketId}`);
         }
         
-        // Add ACA Cold lead tag
+        // Add cold lead tag for this line
         await this.callToolsClient.addTagToContact(
           createdContact.id,
-          'ACA Cold lead'
+          coldLeadTag
         );
         
         await this.createOrUpdateSyncRecord({
@@ -505,7 +586,7 @@ export class ContactSyncService {
         });
         
         result.synced++;
-        console.log(`Created contact ${ghlContact.id} in CallTools and added to Cold Leads bucket`);
+        console.log(`Created contact ${ghlContact.id} in CallTools and added to ${line.label} Cold Leads bucket`);
       }
     } catch (error) {
       await this.updateSyncRecord(ghlContact.id, {

--- a/src/services/contactSyncService.ts
+++ b/src/services/contactSyncService.ts
@@ -2,6 +2,7 @@ import { GoHighLevelClient, GHLContact } from '../clients/gohighlevel';
 import { CallToolsClient, CallToolsContact } from '../clients/calltools';
 import {
   InsuranceLineConfig,
+  LineState,
   getInsuranceLines,
   matchInsuranceLine,
 } from '../config/insuranceLines';
@@ -91,101 +92,52 @@ export class ContactSyncService {
 
       // Check tags
       const tags: string[] = Array.isArray(ghlContact.tags)
-        ? (ghlContact.tags as string[]).map((t) => String(t).toLowerCase())
+        ? (ghlContact.tags as string[]).map((t) => String(t))
         : [];
 
-      // Determine which insurance line (and cold vs active) this contact maps to
+      // Determine which insurance line + state (cold/hot/active) this maps to
       const match = matchInsuranceLine(tags, this.lines);
-
-      // Active clients take priority across all lines (ACA, Auto, ...)
-      if (match && match.type === 'active') {
-        console.log(
-          `Contact ${ghlContactId} matched active client for line "${match.line.label}"`
-        );
-        return await this.syncActiveClient(ghlContact, match.line);
-      }
-
-      // Hot leads (engaged but not yet sold) - promote to the line's hot bucket
-      if (match && match.type === 'hot') {
-        console.log(
-          `Contact ${ghlContactId} matched hot lead for line "${match.line.label}"`
-        );
-        return await this.promoteContact(ghlContact, match.line, 'hot');
-      }
 
       // Generic customer exclusion (not tied to a specific line). A contact
       // flagged as a generic customer/won/purchased lead should never be dialed
-      // as a cold lead.
-      const isCustomer = tags.some(tag =>
-        tag.includes('customer') ||
-        tag.includes('client') ||
-        tag.includes('won') ||
-        tag.includes('purchased')
-      );
+      // as a cold/hot lead. Active matches are allowed through (they ARE
+      // customers and route to the active bucket).
+      const looksLikeCustomer = tags.some((raw) => {
+        const tag = raw.toLowerCase();
+        return (
+          tag.includes('customer') ||
+          tag.includes('client') ||
+          tag.includes('won') ||
+          tag.includes('purchased')
+        );
+      });
 
-      if (isCustomer) {
+      if (match && match.state.name !== 'active' && looksLikeCustomer) {
+        console.log(`Contact ${ghlContactId} excluded: matched ${match.state.name} but has customer/client tags`);
+        await this.markAsCustomer(ghlContactId);
+        return { success: true, contact_id: ghlContactId, action: 'excluded', bucket_id: null };
+      }
+
+      if (match) {
+        console.log(
+          `Contact ${ghlContactId} matched "${match.line.label}" ${match.state.name} state`
+        );
+        return await this.applyState(ghlContact, match.line, match.state);
+      }
+
+      if (looksLikeCustomer) {
         console.log(`Contact ${ghlContactId} excluded: contains customer/client tags`);
         await this.markAsCustomer(ghlContactId);
-        return {
-          success: true,
-          contact_id: ghlContactId,
-          action: 'excluded',
-          bucket_id: null,
-        };
+        return { success: true, contact_id: ghlContactId, action: 'excluded', bucket_id: null };
       }
 
-      if (!match || match.type !== 'cold') {
-        console.log(`Contact ${ghlContactId} excluded: does not match any cold lead or active client line`);
-        return {
-          success: true,
-          contact_id: ghlContactId,
-          action: 'excluded',
-          bucket_id: null,
-          error: 'Contact does not match any cold lead or active client line',
-        };
-      }
-
-      const line = match.line;
-
-      if (!line.coldLeadsBucketId) {
-        console.error(
-          `Contact ${ghlContactId} matched line "${line.label}" cold lead, but no cold leads bucket is configured`
-        );
-        return {
-          success: false,
-          contact_id: ghlContactId,
-          action: 'failed',
-          bucket_id: null,
-          error: `No cold leads bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
-        };
-      }
-
-      console.log(
-        `Contact ${ghlContactId} is a "${line.label}" cold lead, syncing to CallTools bucket ${line.coldLeadsBucketId}`
-      );
-
-      // Sync the contact
-      const result: SyncResult = {
-        total_processed: 1,
-        synced: 0,
-        updated: 0,
-        excluded_customers: 0,
-        failed: 0,
-        bucket_name: `${line.label} Cold Leads`,
-        bucket_id: line.coldLeadsBucketId,
-        errors: [],
-      };
-
-      await this.syncContact(ghlContact, result, line);
-
-      const action = result.synced > 0 ? 'synced' : result.updated > 0 ? 'updated' : 'failed';
-
+      console.log(`Contact ${ghlContactId} excluded: does not match any insurance line state`);
       return {
-        success: result.failed === 0,
+        success: true,
         contact_id: ghlContactId,
-        action,
-        bucket_id: line.coldLeadsBucketId,
-        error: result.errors[0]?.error,
+        action: 'excluded',
+        bucket_id: null,
+        error: 'Contact does not match any insurance line state',
       };
     } catch (error) {
       console.error(`Error syncing single contact ${ghlContactId}:`, error);
@@ -200,33 +152,18 @@ export class ContactSyncService {
   }
 
   /**
-   * Convenience wrapper: promote a contact to the active-client tier.
-   */
-  private async syncActiveClient(
-    ghlContact: GHLContact,
-    line: InsuranceLineConfig
-  ): Promise<{
-    success: boolean;
-    contact_id: string;
-    action: 'synced' | 'updated' | 'excluded' | 'failed';
-    bucket_id: string | null;
-    error?: string;
-  }> {
-    return this.promoteContact(ghlContact, line, 'active');
-  }
-
-  /**
-   * Promote a contact into a higher tier (hot lead or active client) for a line.
+   * Apply an insurance-line state to a contact.
    *
-   * The contact is created/updated in CallTools, added to the target tier's
-   * bucket/tag, and removed from the buckets/tags of all lower tiers. Active
-   * clients are additionally marked as customers in the database (and excluded
-   * from future cold-lead syncs); hot leads are not.
+   * The contact is created/updated in CallTools, added to the state's bucket
+   * and tag, and removed from the buckets/tags listed on the state (e.g. a
+   * cold-lead state removes the contact from the hot bucket). States flagged
+   * `isCustomer` mark the contact as a customer in the DB and exclude it from
+   * future cold syncs.
    */
-  private async promoteContact(
+  private async applyState(
     ghlContact: GHLContact,
     line: InsuranceLineConfig,
-    tier: 'hot' | 'active'
+    state: LineState
   ): Promise<{
     success: boolean;
     contact_id: string;
@@ -235,42 +172,42 @@ export class ContactSyncService {
     error?: string;
   }> {
     try {
-      const isActive = tier === 'active';
-      const tierLabel = isActive ? 'active client' : 'hot lead';
+      const stateLabel = `${line.label} ${state.name}`;
+      console.log(`Processing ${stateLabel}: ${ghlContact.id}`);
 
-      // Resolve the target bucket/tag and the lower tiers to clean up.
-      const targetBucketId = isActive ? line.activeClientsBucketId : (line.hotLeadsBucketId || '');
-      const targetTag = isActive ? line.activeClientTag : (line.hotLeadTag || '');
-
-      // Lower-tier buckets/tags to remove the contact from on promotion.
-      const removeBucketIds: string[] = [];
-      const removeTags: string[] = [];
-      if (line.coldLeadsBucketId) removeBucketIds.push(line.coldLeadsBucketId);
-      if (line.coldLeadTag) removeTags.push(line.coldLeadTag);
-      if (isActive) {
-        if (line.hotLeadsBucketId) removeBucketIds.push(line.hotLeadsBucketId);
-        if (line.hotLeadTag) removeTags.push(line.hotLeadTag);
-      }
-
-      console.log(`Processing ${tierLabel} for line "${line.label}": ${ghlContact.id}`);
-
-      if (!targetBucketId || !targetTag) {
-        console.error(
-          `No ${tierLabel} bucket configured for line "${line.label}", cannot sync ${ghlContact.id}`
-        );
+      if (!state.bucketId) {
+        console.error(`No bucket configured for "${stateLabel}", cannot sync ${ghlContact.id}`);
         return {
           success: false,
           contact_id: ghlContact.id,
           action: 'failed',
           bucket_id: null,
-          error: `No ${tierLabel} bucket configured for line "${line.label}". Set the corresponding bucket env var.`,
+          error: `No bucket configured for "${stateLabel}". Set the corresponding bucket env var.`,
         };
+      }
+
+      // Don't re-add a known customer to a non-customer (cold/hot) bucket.
+      if (!state.isCustomer) {
+        const existingRecord = await this.getSyncedContact(ghlContact.id);
+        if (existingRecord && existingRecord.is_customer === 1) {
+          console.log(`Contact ${ghlContact.id} is a known customer, skipping ${state.name} sync`);
+          return {
+            success: true,
+            contact_id: ghlContact.id,
+            action: 'excluded',
+            bucket_id: null,
+          };
+        }
       }
 
       // Check if contact has phone number
       const phone = ghlContact.phone || '';
       if (!phone) {
         console.warn(`Contact ${ghlContact.id} has no phone number, skipping`);
+        await this.updateSyncRecord(ghlContact.id, {
+          sync_status: 'failed',
+          error_message: 'No phone number',
+        });
         return {
           success: false,
           contact_id: ghlContact.id,
@@ -286,7 +223,7 @@ export class ContactSyncService {
         last_name: ghlContact.lastName || '',
         mobile_phone_number: phone,
         personal_email_address: ghlContact.email || '',
-        bucket_id: targetBucketId,
+        bucket_id: state.bucketId,
       };
 
       // Check if contact already exists in CallTools (search by phone)
@@ -295,41 +232,42 @@ export class ContactSyncService {
         phone
       );
 
-      const contactId = existingCallToolsContact ? existingCallToolsContact.id : null;
-      const isUpdate = contactId !== null;
+      const isUpdate = existingCallToolsContact !== null;
 
       let resolvedContactId: string;
       if (isUpdate) {
-        console.log(`Updating existing contact ${ghlContact.id} as ${tierLabel}`);
-        await this.callToolsClient.updateContact(contactId!, callToolsContact);
-        resolvedContactId = contactId!;
+        console.log(`Updating existing contact ${ghlContact.id} as ${stateLabel}`);
+        await this.callToolsClient.updateContact(existingCallToolsContact!.id, callToolsContact);
+        resolvedContactId = existingCallToolsContact!.id;
       } else {
-        console.log(`Creating new contact ${ghlContact.id} as ${tierLabel}`);
+        console.log(`Creating new contact ${ghlContact.id} as ${stateLabel}`);
         const createdContact = await this.callToolsClient.createContact(callToolsContact);
         console.log(`Created contact with ID: ${createdContact.id}`);
         resolvedContactId = createdContact.id;
       }
 
-      // Add to the target tier bucket
-      await this.callToolsClient.addContactToBucket(resolvedContactId, targetBucketId);
-      console.log(`Added contact to ${tierLabel} bucket (${targetBucketId})`);
+      // Add to the state's bucket
+      await this.callToolsClient.addContactToBucket(resolvedContactId, state.bucketId);
+      console.log(`Added contact to ${stateLabel} bucket (${state.bucketId})`);
 
-      // Add the target tier tag
-      await this.callToolsClient.addTagToContact(resolvedContactId, targetTag);
-      console.log(`Added "${targetTag}" tag`);
+      // Add the state's tag
+      await this.callToolsClient.addTagToContact(resolvedContactId, state.tag);
+      console.log(`Added "${state.tag}" tag`);
 
-      // Remove from lower-tier buckets
-      for (const bucketId of removeBucketIds) {
+      // Remove from the configured buckets
+      for (const bucketId of state.removeBucketIds) {
+        if (!bucketId || bucketId === state.bucketId) continue;
         try {
           await this.callToolsClient.removeContactFromBucket(resolvedContactId, bucketId);
-          console.log(`Removed contact from lower-tier bucket (${bucketId})`);
+          console.log(`Removed contact from bucket (${bucketId})`);
         } catch (error) {
           console.log(`Could not remove from bucket ${bucketId} (may not be in it):`, error);
         }
       }
 
-      // Remove lower-tier tags
-      for (const tag of removeTags) {
+      // Remove the configured tags
+      for (const tag of state.removeTags) {
+        if (!tag || tag === state.tag) continue;
         try {
           await this.callToolsClient.removeTagFromContact(resolvedContactId, tag);
           console.log(`Removed "${tag}" tag`);
@@ -349,24 +287,27 @@ export class ContactSyncService {
         sync_status: 'synced',
         last_sync_at: new Date().toISOString(),
         error_message: null,
-        is_customer: isActive ? 1 : 0,
+        is_customer: state.isCustomer ? 1 : 0,
       });
 
-      // Active clients are excluded from future cold syncs
-      if (isActive) {
+      if (state.isCustomer) {
         await this.markAsCustomer(ghlContact.id);
       }
 
-      console.log(`Successfully ${isUpdate ? 'updated' : 'created'} contact ${ghlContact.id} as ${tierLabel}`);
+      console.log(`Successfully ${isUpdate ? 'updated' : 'created'} contact ${ghlContact.id} as ${stateLabel}`);
 
       return {
         success: true,
         contact_id: ghlContact.id,
         action: isUpdate ? 'updated' : 'synced',
-        bucket_id: targetBucketId,
+        bucket_id: state.bucketId,
       };
     } catch (error) {
-      console.error(`Error syncing ${tier} for ${ghlContact.id}:`, error);
+      console.error(`Error applying state ${state.name} for ${ghlContact.id}:`, error);
+      await this.updateSyncRecord(ghlContact.id, {
+        sync_status: 'failed',
+        error_message: error instanceof Error ? error.message : 'Unknown error',
+      });
       return {
         success: false,
         contact_id: ghlContact.id,
@@ -402,59 +343,42 @@ export class ContactSyncService {
       const allContacts = await this.ghlClient.getAllContacts();
       console.log(`Fetched ${allContacts.length} contacts from GoHighLevel`);
 
-      // Route each contact to the correct insurance line
+      // Route each contact to the correct insurance line + state
       for (const ghlContact of allContacts) {
-        const tags = (ghlContact.tags || []).map((t) => t.toLowerCase());
+        const tags = (ghlContact.tags || []).map((t) => String(t));
         const match = matchInsuranceLine(tags, this.lines);
 
         if (!match) {
-          continue; // Not a cold lead or active client for any line
+          continue; // Doesn't match any insurance line state
+        }
+
+        // Skip generic customers (won/purchased) that aren't an active match
+        const looksLikeCustomer = tags.some((raw) => {
+          const tag = raw.toLowerCase();
+          return tag.includes('customer') || tag.includes('won') || tag.includes('purchased');
+        });
+        if (match.state.name !== 'active' && looksLikeCustomer) {
+          result.excluded_customers++;
+          await this.markAsCustomer(ghlContact.id);
+          continue;
         }
 
         result.total_processed++;
 
         try {
-          if (match.type === 'active' || match.type === 'hot') {
-            const promoteResult =
-              match.type === 'active'
-                ? await this.syncActiveClient(ghlContact, match.line)
-                : await this.promoteContact(ghlContact, match.line, 'hot');
-            if (promoteResult.action === 'synced') {
-              result.synced++;
-            } else if (promoteResult.action === 'updated') {
-              result.updated++;
-            } else if (promoteResult.action === 'failed') {
-              result.failed++;
-              if (promoteResult.error) {
-                result.errors.push({ contact_id: ghlContact.id, error: promoteResult.error });
-              }
-            }
-            continue;
-          }
-
-          // Cold lead: skip generic customers (won/purchased) that aren't active
-          const isCustomer = tags.some(
-            (tag) =>
-              tag.includes('customer') ||
-              tag.includes('won') ||
-              tag.includes('purchased')
-          );
-          if (isCustomer) {
+          const stateResult = await this.applyState(ghlContact, match.line, match.state);
+          if (stateResult.action === 'synced') {
+            result.synced++;
+          } else if (stateResult.action === 'updated') {
+            result.updated++;
+          } else if (stateResult.action === 'excluded') {
             result.excluded_customers++;
-            await this.markAsCustomer(ghlContact.id);
-            continue;
-          }
-
-          if (!match.line.coldLeadsBucketId) {
+          } else if (stateResult.action === 'failed') {
             result.failed++;
-            result.errors.push({
-              contact_id: ghlContact.id,
-              error: `No cold leads bucket configured for line "${match.line.label}"`,
-            });
-            continue;
+            if (stateResult.error) {
+              result.errors.push({ contact_id: ghlContact.id, error: stateResult.error });
+            }
           }
-
-          await this.syncContact(ghlContact, result, match.line);
         } catch (error) {
           result.failed++;
           result.errors.push({
@@ -469,129 +393,6 @@ export class ContactSyncService {
       return result;
     } catch (error) {
       console.error('Error during sync:', error);
-      throw error;
-    }
-  }
-
-  /**
-   * Sync a single cold-lead contact into the bucket/tag for its insurance line.
-   */
-  private async syncContact(ghlContact: GHLContact, result: SyncResult, line: InsuranceLineConfig): Promise<void> {
-    const bucketId = line.coldLeadsBucketId;
-    const coldLeadTag = line.coldLeadTag;
-
-    // Check if contact is already tracked in our database
-    const existingRecord = await this.getSyncedContact(ghlContact.id);
-
-    // Skip if marked as customer
-    if (existingRecord && existingRecord.is_customer === 1) {
-      result.excluded_customers++;
-      return;
-    }
-
-    // Prepare CallTools contact data
-    const phone = ghlContact.phone || '';
-    if (!phone) {
-      console.warn(`Contact ${ghlContact.id} has no phone number, skipping`);
-      await this.updateSyncRecord(ghlContact.id, {
-        sync_status: 'failed',
-        error_message: 'No phone number',
-      });
-      result.failed++;
-      return;
-    }
-
-    const callToolsContact: CallToolsContact = {
-      first_name: ghlContact.firstName || ghlContact.name || 'Unknown',
-      last_name: ghlContact.lastName || '',
-      mobile_phone_number: phone,
-      personal_email_address: ghlContact.email || '',
-      bucket_id: bucketId, // Assign to this line's Cold Leads bucket
-      // Don't send tags in create payload - add them separately after creation
-    };
-
-    try {
-      // Check if contact already exists in CallTools (search by phone)
-      const existingCallToolsContact = await this.callToolsClient.getContactByExternalId(
-        ghlContact.id,
-        phone
-      );
-
-      if (existingCallToolsContact) {
-        // Update existing contact
-        await this.callToolsClient.updateContact(
-          existingCallToolsContact.id,
-          callToolsContact
-        );
-        
-        // Add contact to Cold Leads bucket
-        if (bucketId) {
-          await this.callToolsClient.addContactToBucket(
-            existingCallToolsContact.id,
-            bucketId
-          );
-          console.log(`Added contact ${existingCallToolsContact.id} to bucket ${bucketId}`);
-        }
-        
-        // Add cold lead tag for this line
-        await this.callToolsClient.addTagToContact(
-          existingCallToolsContact.id,
-          coldLeadTag
-        );
-        
-        await this.updateSyncRecord(ghlContact.id, {
-          calltools_contact_id: existingCallToolsContact.id,
-          first_name: callToolsContact.first_name,
-          last_name: callToolsContact.last_name,
-          phone: callToolsContact.mobile_phone_number,
-          email: callToolsContact.email,
-          sync_status: 'synced',
-          last_sync_at: new Date().toISOString(),
-          error_message: null,
-        });
-        
-        result.updated++;
-        console.log(`Updated contact ${ghlContact.id} in CallTools and added to ${line.label} Cold Leads bucket`);
-      } else {
-        // Create new contact
-        const createdContact = await this.callToolsClient.createContact(callToolsContact);
-        
-        // Add contact to Cold Leads bucket
-        if (bucketId) {
-          await this.callToolsClient.addContactToBucket(
-            createdContact.id,
-            bucketId
-          );
-          console.log(`Added contact ${createdContact.id} to bucket ${bucketId}`);
-        }
-        
-        // Add cold lead tag for this line
-        await this.callToolsClient.addTagToContact(
-          createdContact.id,
-          coldLeadTag
-        );
-        
-        await this.createOrUpdateSyncRecord({
-          ghl_contact_id: ghlContact.id,
-          calltools_contact_id: createdContact.id,
-          first_name: callToolsContact.first_name,
-          last_name: callToolsContact.last_name || null,
-          phone: callToolsContact.mobile_phone_number || null,
-          email: callToolsContact.email || null,
-          sync_status: 'synced',
-          last_sync_at: new Date().toISOString(),
-          error_message: null,
-          is_customer: 0,
-        });
-        
-        result.synced++;
-        console.log(`Created contact ${ghlContact.id} in CallTools and added to ${line.label} Cold Leads bucket`);
-      }
-    } catch (error) {
-      await this.updateSyncRecord(ghlContact.id, {
-        sync_status: 'failed',
-        error_message: error instanceof Error ? error.message : 'Unknown error',
-      });
       throw error;
     }
   }

--- a/src/services/contactSyncService.ts
+++ b/src/services/contactSyncService.ts
@@ -112,7 +112,13 @@ export class ContactSyncService {
         );
       });
 
-      if (match && match.state.name !== 'active' && looksLikeCustomer) {
+      // Cold/hot states are blocked if the contact looks like a customer.
+      // Active and winback states are exempt (winback deliberately re-pursues
+      // past customers).
+      const stateExemptFromCustomerCheck =
+        !!match && (match.state.isCustomer || !!match.state.overridesCustomer);
+
+      if (match && !stateExemptFromCustomerCheck && looksLikeCustomer) {
         console.log(`Contact ${ghlContactId} excluded: matched ${match.state.name} but has customer/client tags`);
         await this.markAsCustomer(ghlContactId);
         return { success: true, contact_id: ghlContactId, action: 'excluded', bucket_id: null };
@@ -186,8 +192,9 @@ export class ContactSyncService {
         };
       }
 
-      // Don't re-add a known customer to a non-customer (cold/hot) bucket.
-      if (!state.isCustomer) {
+      // Don't re-add a known customer to a non-customer (cold/hot) bucket,
+      // unless the state explicitly overrides this (e.g. winback).
+      if (!state.isCustomer && !state.overridesCustomer) {
         const existingRecord = await this.getSyncedContact(ghlContact.id);
         if (existingRecord && existingRecord.is_customer === 1) {
           console.log(`Contact ${ghlContact.id} is a known customer, skipping ${state.name} sync`);
@@ -352,12 +359,14 @@ export class ContactSyncService {
           continue; // Doesn't match any insurance line state
         }
 
-        // Skip generic customers (won/purchased) that aren't an active match
+        // Skip generic customers (won/purchased) unless the matched state is a
+        // customer state (active) or overrides the customer flag (winback).
         const looksLikeCustomer = tags.some((raw) => {
           const tag = raw.toLowerCase();
           return tag.includes('customer') || tag.includes('won') || tag.includes('purchased');
         });
-        if (match.state.name !== 'active' && looksLikeCustomer) {
+        const stateExemptFromCustomerCheck = match.state.isCustomer || !!match.state.overridesCustomer;
+        if (!stateExemptFromCustomerCheck && looksLikeCustomer) {
           result.excluded_customers++;
           await this.markAsCustomer(ghlContact.id);
           continue;

--- a/tests/integration/insuranceLines.test.ts
+++ b/tests/integration/insuranceLines.test.ts
@@ -9,12 +9,13 @@ function match(tags: string[]) {
 }
 
 describe('Auto Insurance routing', () => {
-  it('routes "auto – autoquote click" to the Auto Hot Leads bucket', () => {
-    expect(match(['auto – autoquote click'])).toEqual({
-      line: 'auto',
-      state: 'hot',
-      bucket: '11879',
-    });
+  it('routes "auto – autoquote click" to the Auto Hot Leads bucket and removes Cold', () => {
+    const m = matchInsuranceLine(['auto – autoquote click'], lines)!;
+    expect(m.line.key).toBe('auto');
+    expect(m.state.name).toBe('hot');
+    expect(m.state.bucketId).toBe('11879');
+    expect(m.state.removeBucketIds).toContain('11880');
+    expect(m.state.removeTags).toContain('Auto Cold lead');
   });
 
   it('routes "cold_lead_auto" to the Auto Cold Leads bucket and removes Hot', () => {
@@ -36,9 +37,9 @@ describe('Auto Insurance routing', () => {
     expect(m.state.removeTags).toEqual(expect.arrayContaining(['Auto Cold lead', 'Auto Hot lead']));
   });
 
-  it('prefers cold over hot when both tags are present (cold wins)', () => {
-    // A lead that was hot, then tagged cold, should land in Cold (and removes Hot)
-    expect(match(['auto – autoquote click', 'cold_lead_auto'])?.state).toBe('cold');
+  it('prefers hot over cold when both tags are present (re-engagement wins)', () => {
+    // A cold lead showing renewed buying intent should land in Hot (removes Cold)
+    expect(match(['cold_lead_auto', 'auto – autoquote click'])?.state).toBe('hot');
   });
 
   it('prefers active over everything when all tags are present', () => {

--- a/tests/integration/insuranceLines.test.ts
+++ b/tests/integration/insuranceLines.test.ts
@@ -88,4 +88,22 @@ describe('ACA Insurance routing (unchanged)', () => {
   it('returns null when no insurance tag is present', () => {
     expect(match(['random tag', 'newsletter'])).toBeNull();
   });
+
+  it('routes "winback – aca" to the Win-Back bucket with the winback tag', () => {
+    const m = matchInsuranceLine(['winback – aca'], lines)!;
+    expect(m.line.key).toBe('aca');
+    expect(m.state.name).toBe('winback');
+    expect(m.state.bucketId).toBe('11238');
+    expect(m.state.tag).toBe('winback – aca');
+    expect(m.state.isCustomer).toBe(false);
+    expect(m.state.overridesCustomer).toBe(true);
+    expect(m.state.removeBucketIds).toEqual(expect.arrayContaining(['11237', '11252']));
+    expect(m.state.removeTags).toEqual(
+      expect.arrayContaining(['ACA Cold Lead', 'ACA Active Client'])
+    );
+  });
+
+  it('prefers active over winback when both tags are present (re-sold wins)', () => {
+    expect(match(['winback – aca', 'aca active 2026'])?.state).toBe('active');
+  });
 });

--- a/tests/integration/insuranceLines.test.ts
+++ b/tests/integration/insuranceLines.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { getInsuranceLines, matchInsuranceLine } from '../../src/config/insuranceLines';
+
+const lines = getInsuranceLines({});
+
+function match(tags: string[]) {
+  const m = matchInsuranceLine(tags, lines);
+  return m ? { line: m.line.key, state: m.state.name, bucket: m.state.bucketId } : null;
+}
+
+describe('Auto Insurance routing', () => {
+  it('routes "auto – autoquote click" to the Auto Hot Leads bucket', () => {
+    expect(match(['auto – autoquote click'])).toEqual({
+      line: 'auto',
+      state: 'hot',
+      bucket: '11879',
+    });
+  });
+
+  it('routes "cold_lead_auto" to the Auto Cold Leads bucket and removes Hot', () => {
+    const m = matchInsuranceLine(['cold_lead_auto'], lines)!;
+    expect(m.line.key).toBe('auto');
+    expect(m.state.name).toBe('cold');
+    expect(m.state.bucketId).toBe('11880');
+    expect(m.state.removeBucketIds).toContain('11879');
+    expect(m.state.removeTags).toContain('Auto Hot lead');
+  });
+
+  it('routes "auto – active" to the Auto Active Clients bucket and removes Cold + Hot', () => {
+    const m = matchInsuranceLine(['auto – active'], lines)!;
+    expect(m.line.key).toBe('auto');
+    expect(m.state.name).toBe('active');
+    expect(m.state.bucketId).toBe('11881');
+    expect(m.state.isCustomer).toBe(true);
+    expect(m.state.removeBucketIds).toEqual(expect.arrayContaining(['11880', '11879']));
+    expect(m.state.removeTags).toEqual(expect.arrayContaining(['Auto Cold lead', 'Auto Hot lead']));
+  });
+
+  it('prefers cold over hot when both tags are present (cold wins)', () => {
+    // A lead that was hot, then tagged cold, should land in Cold (and removes Hot)
+    expect(match(['auto – autoquote click', 'cold_lead_auto'])?.state).toBe('cold');
+  });
+
+  it('prefers active over everything when all tags are present', () => {
+    expect(
+      match(['auto – autoquote click', 'cold_lead_auto', 'auto – active'])?.state
+    ).toBe('active');
+  });
+
+  it('matches regardless of dash style or casing', () => {
+    expect(match(['AUTO - ACTIVE'])?.state).toBe('active');
+    expect(match(['Auto — Autoquote Click'])?.state).toBe('hot');
+  });
+});
+
+describe('ACA Insurance routing (unchanged)', () => {
+  it('routes a generic cold lead to the ACA Cold bucket', () => {
+    expect(match(['cold lead'])).toEqual({
+      line: 'aca',
+      state: 'cold',
+      bucket: '11237',
+    });
+  });
+
+  it('routes "ACA Active 2026" to the ACA Active bucket', () => {
+    const m = matchInsuranceLine(['ACA Active 2026'], lines)!;
+    expect(m.line.key).toBe('aca');
+    expect(m.state.name).toBe('active');
+    expect(m.state.bucketId).toBe('11252');
+  });
+
+  it('returns null when no insurance tag is present', () => {
+    expect(match(['random tag', 'newsletter'])).toBeNull();
+  });
+});

--- a/tests/integration/insuranceLines.test.ts
+++ b/tests/integration/insuranceLines.test.ts
@@ -68,19 +68,21 @@ describe('Auto Insurance routing', () => {
 });
 
 describe('ACA Insurance routing (unchanged)', () => {
-  it('routes a generic cold lead to the ACA Cold bucket', () => {
-    expect(match(['cold lead'])).toEqual({
-      line: 'aca',
-      state: 'cold',
-      bucket: '11237',
-    });
+  it('routes a generic cold lead to the ACA Cold bucket with the ACA Cold Lead tag', () => {
+    const m = matchInsuranceLine(['cold lead'], lines)!;
+    expect(m.line.key).toBe('aca');
+    expect(m.state.name).toBe('cold');
+    expect(m.state.bucketId).toBe('11237');
+    expect(m.state.tag).toBe('ACA Cold Lead');
   });
 
-  it('routes "ACA Active 2026" to the ACA Active bucket', () => {
+  it('routes "ACA Active 2026" to the ACA Active bucket with the ACA Active Client tag', () => {
     const m = matchInsuranceLine(['ACA Active 2026'], lines)!;
     expect(m.line.key).toBe('aca');
     expect(m.state.name).toBe('active');
     expect(m.state.bucketId).toBe('11252');
+    expect(m.state.tag).toBe('ACA Active Client');
+    expect(m.state.removeTags).toContain('ACA Cold Lead');
   });
 
   it('returns null when no insurance tag is present', () => {

--- a/tests/integration/insuranceLines.test.ts
+++ b/tests/integration/insuranceLines.test.ts
@@ -14,8 +14,13 @@ describe('Auto Insurance routing', () => {
     expect(m.line.key).toBe('auto');
     expect(m.state.name).toBe('hot');
     expect(m.state.bucketId).toBe('11879');
+    expect(m.state.tag).toBe('Auto Insurance Hot Leads');
     expect(m.state.removeBucketIds).toContain('11880');
-    expect(m.state.removeTags).toContain('Auto Cold lead');
+    expect(m.state.removeTags).toContain('Auto Insurance Cold Leads');
+  });
+
+  it('routes the "Auto Insurance Hot Leads" tag to the Hot bucket', () => {
+    expect(match(['Auto Insurance Hot Leads'])?.state).toBe('hot');
   });
 
   it('routes "cold_lead_auto" to the Auto Cold Leads bucket and removes Hot', () => {
@@ -23,8 +28,13 @@ describe('Auto Insurance routing', () => {
     expect(m.line.key).toBe('auto');
     expect(m.state.name).toBe('cold');
     expect(m.state.bucketId).toBe('11880');
+    expect(m.state.tag).toBe('Auto Insurance Cold Leads');
     expect(m.state.removeBucketIds).toContain('11879');
-    expect(m.state.removeTags).toContain('Auto Hot lead');
+    expect(m.state.removeTags).toContain('Auto Insurance Hot Leads');
+  });
+
+  it('routes the "Auto Insurance Cold Leads" tag to the Cold bucket', () => {
+    expect(match(['Auto Insurance Cold Leads'])?.state).toBe('cold');
   });
 
   it('routes "auto – active" to the Auto Active Clients bucket and removes Cold + Hot', () => {
@@ -32,9 +42,12 @@ describe('Auto Insurance routing', () => {
     expect(m.line.key).toBe('auto');
     expect(m.state.name).toBe('active');
     expect(m.state.bucketId).toBe('11881');
+    expect(m.state.tag).toBe('auto – active');
     expect(m.state.isCustomer).toBe(true);
     expect(m.state.removeBucketIds).toEqual(expect.arrayContaining(['11880', '11879']));
-    expect(m.state.removeTags).toEqual(expect.arrayContaining(['Auto Cold lead', 'Auto Hot lead']));
+    expect(m.state.removeTags).toEqual(
+      expect.arrayContaining(['Auto Insurance Cold Leads', 'Auto Insurance Hot Leads'])
+    );
   });
 
   it('prefers hot over cold when both tags are present (re-engagement wins)', () => {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -8,6 +8,10 @@ declare namespace Cloudflare {
 		CALLTOOLS_API_KEY: string;
 		CALLTOOLS_BASE_URL?: string;
 		GHL_WEBHOOK_SECRET?: string;
+		ACA_COLD_LEADS_BUCKET_ID?: string;
+		ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
+		AUTO_COLD_LEADS_BUCKET_ID?: string;
+		AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -11,6 +11,7 @@ declare namespace Cloudflare {
 		ACA_COLD_LEADS_BUCKET_ID?: string;
 		ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
 		AUTO_COLD_LEADS_BUCKET_ID?: string;
+		AUTO_HOT_LEADS_BUCKET_ID?: string;
 		AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;
 	}
 }

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -10,6 +10,7 @@ declare namespace Cloudflare {
 		GHL_WEBHOOK_SECRET?: string;
 		ACA_COLD_LEADS_BUCKET_ID?: string;
 		ACA_ACTIVE_CLIENTS_BUCKET_ID?: string;
+		ACA_WINBACK_BUCKET_ID?: string;
 		AUTO_COLD_LEADS_BUCKET_ID?: string;
 		AUTO_HOT_LEADS_BUCKET_ID?: string;
 		AUTO_ACTIVE_CLIENTS_BUCKET_ID?: string;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,7 +17,15 @@
   // Environment variables for API integrations
   // Note: Set these via: wrangler secret put <SECRET_NAME>
   "vars": {
-    "CALLTOOLS_BASE_URL": "https://east-1.calltools.io"
+    "CALLTOOLS_BASE_URL": "https://east-1.calltools.io",
+    // CallTools bucket IDs per insurance line.
+    // ACA defaults match the historical hardcoded values; override if needed.
+    "ACA_COLD_LEADS_BUCKET_ID": "11237",
+    "ACA_ACTIVE_CLIENTS_BUCKET_ID": "11252",
+    // Auto Insurance buckets - REPLACE with the real bucket IDs from CallTools.
+    // Until these are set, Auto contacts will be skipped with a clear error.
+    "AUTO_COLD_LEADS_BUCKET_ID": "",
+    "AUTO_ACTIVE_CLIENTS_BUCKET_ID": ""
   }
   // Secrets (set via wrangler secret put):
   // - GHL_API_KEY: GoHighLevel API key

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,6 +22,7 @@
     // ACA defaults match the historical hardcoded values; override if needed.
     "ACA_COLD_LEADS_BUCKET_ID": "11237",
     "ACA_ACTIVE_CLIENTS_BUCKET_ID": "11252",
+    "ACA_WINBACK_BUCKET_ID": "11238",
     // Auto Insurance buckets (CallTools).
     "AUTO_COLD_LEADS_BUCKET_ID": "11880",
     "AUTO_HOT_LEADS_BUCKET_ID": "11879",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,10 +22,10 @@
     // ACA defaults match the historical hardcoded values; override if needed.
     "ACA_COLD_LEADS_BUCKET_ID": "11237",
     "ACA_ACTIVE_CLIENTS_BUCKET_ID": "11252",
-    // Auto Insurance buckets - REPLACE with the real bucket IDs from CallTools.
-    // Until these are set, Auto contacts will be skipped with a clear error.
-    "AUTO_COLD_LEADS_BUCKET_ID": "",
-    "AUTO_ACTIVE_CLIENTS_BUCKET_ID": ""
+    // Auto Insurance buckets (CallTools).
+    "AUTO_COLD_LEADS_BUCKET_ID": "11880",
+    "AUTO_HOT_LEADS_BUCKET_ID": "11879",
+    "AUTO_ACTIVE_CLIENTS_BUCKET_ID": "11881"
   }
   // Secrets (set via wrangler secret put):
   // - GHL_API_KEY: GoHighLevel API key


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generalizes the CallTools ↔ GoHighLevel integration into configurable per-line **states** (each with its own bucket, CallTools tag, and explicit add/remove rules), and adds a full **Auto Insurance** line plus an **ACA Win-Back** state. ACA's original cold/active behavior is preserved.

## Routing rules

**Auto Insurance**

| GHL trigger tag | Bucket added | Removed from | CallTools tag |
|-----------------|--------------|--------------|---------------|
| `auto – autoquote click` / `Auto Insurance Hot Leads` | Hot (`11879`) | Cold (`11880`) | `Auto Insurance Hot Leads` (142724) |
| `cold_lead_auto` / `Auto Insurance Cold Leads` | Cold (`11880`) | Hot (`11879`) | `Auto Insurance Cold Leads` (142725) |
| `auto – active` | Active (`11881`) | Cold + Hot | `auto – active` (142754) |

**ACA / Health**

| GHL trigger tag | Bucket added | Removed from | CallTools tag |
|-----------------|--------------|--------------|---------------|
| generic cold (`cold lead`, `prospect`, …) | Cold (`11237`) | — | `ACA Cold Lead` (128365) |
| `aca active 2025/2026` | Active (`11252`) | Cold + Winback | `ACA Active Client` (129315) |
| `winback – aca` | Win-Back (`11238`) | Cold + Active | `winback – aca` (132076) |

- Cold ↔ hot is bidirectional (Auto). Active is terminal/customer.
- **Winback** re-pursues lapsed/cancelled ACA clients: it overrides the "is customer" guard and resets the flag so they're callable again. If they re-buy, active out-prioritizes winback.
- Priority when multiple tags are present: **active > winback > hot > cold**.
- Tag matching is normalized (case / en-em-dash / spacing insensitive).

## What changed

- **`src/config/insuranceLines.ts`** — per-line `states` model (`matchers`, `bucketId`, `tag`, `removeBucketIds`, `removeTags`, `isCustomer`, `overridesCustomer`), `normalizeTag()`, priority-based `matchInsuranceLine()`. Uses the real CallTools tag names/IDs.
- **`ContactSyncService`** — unified `applyState()` drives single + batch sync; customer-exclusion guards honor `overridesCustomer`.
- **GHL client** — `getAllContacts()` for multi-line batch sync.
- **Endpoints** — pass `getInsuranceLines(env)`.
- **Config** — `ACA_*` (incl. `ACA_WINBACK_BUCKET_ID`) and `AUTO_*` bucket env vars in `wrangler.jsonc`, types, `.env.example`, defaulted to the real bucket IDs.
- **Tests** — `tests/integration/insuranceLines.test.ts` (25 tests) covering every state, removals, priority, casing, and the winback customer override.
- **Docs** — `AUTO_INSURANCE_FEATURE.md`, ACA winback section in `ACTIVE_CLIENTS_FEATURE.md`, `CALLTOOLS_LIVE_FILTERS.md`, README note.

## GoHighLevel setup

Reuse the same webhook endpoint for all states; fire workflows on the trigger tags, each POSTing `{ "contact_id": "{{contact.id}}" }`. For winback, have the workflow remove the `ACA Active` tag when adding `winback – aca` so winback isn't out-prioritized by active.

## Testing

- `wrangler deploy --dry-run` builds; all six bucket bindings resolve.
- `vitest` suite passes (25/25).
- Files touched by this PR are clean under strict `tsc` (pre-existing strict-tsc warnings in `calltools.ts` / `tasks/*` are unchanged; the project builds via esbuild).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92857d1c-8d08-4ab2-a347-2412f63b4cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92857d1c-8d08-4ab2-a347-2412f63b4cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

